### PR TITLE
Redesign trades table layout and add buy/sell indicators

### DIFF
--- a/src/components/table-skeleton.tsx
+++ b/src/components/table-skeleton.tsx
@@ -58,7 +58,7 @@ export function AccountsTableSkeleton({ rows = 5 }: { rows?: number }) {
   );
 }
 
-// Pre-configured skeleton for trades table (8 columns with account, 7 without)
+// Pre-configured skeleton for trades table (6 columns - Order ID removed, account merged with time)
 export function TradesTableSkeleton({
   rows = 5,
   showAccount = false,
@@ -66,10 +66,10 @@ export function TradesTableSkeleton({
   rows?: number;
   showAccount?: boolean;
 }) {
-  const columns = showAccount ? 8 : 7;
+  // Time column is wider when showing account info underneath
   const widths = showAccount
-    ? ["w-32", "w-28", "w-20", "w-14", "w-20", "w-20", "w-16", "w-20"]
-    : ["w-32", "w-20", "w-14", "w-20", "w-20", "w-16", "w-20"];
+    ? ["w-40", "w-20", "w-14", "w-20", "w-20", "w-16"]
+    : ["w-32", "w-20", "w-14", "w-20", "w-20", "w-16"];
 
-  return <TableSkeleton rows={rows} columns={columns} columnWidths={widths} />;
+  return <TableSkeleton rows={rows} columns={6} columnWidths={widths} />;
 }

--- a/src/components/trades-table.tsx
+++ b/src/components/trades-table.tsx
@@ -9,7 +9,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { TradesTableSkeleton } from "@/components/table-skeleton";
 import { cn } from "@/lib/utils";
@@ -37,11 +36,6 @@ function formatNumber(value: string, decimals: number = 4): string {
     minimumFractionDigits: 0,
     maximumFractionDigits: decimals,
   });
-}
-
-function truncateId(id: string, chars: number = 8): string {
-  if (id.length <= chars) return id;
-  return `${id.slice(0, chars)}...`;
 }
 
 export function TradesTable({
@@ -80,65 +74,67 @@ export function TradesTable({
         <TableHeader>
           <TableRow>
             <TableHead>Time</TableHead>
-            {showAccount && <TableHead>Account</TableHead>}
             <TableHead>Pair</TableHead>
             <TableHead>Side</TableHead>
             <TableHead className="text-right">Price</TableHead>
             <TableHead className="text-right">Quantity</TableHead>
             <TableHead className="text-right">Fee</TableHead>
-            <TableHead>Order ID</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {trades.map((trade) => (
             <TableRow
               key={trade.id}
-              className={cn(isNewItem?.(trade.id) && "animate-highlight-new")}
-            >
-              <TableCell className="text-sm text-muted-foreground">
-                {formatTimestamp(trade.timestamp)}
-              </TableCell>
-              {showAccount && (
-                <TableCell>
-                  <div className="flex flex-col">
-                    <span className="font-medium text-sm">
-                      {trade.exchange_account?.exchange?.display_name || "Unknown"}
-                    </span>
-                    <span className="text-xs text-muted-foreground font-mono">
-                      {truncateId(
-                        trade.exchange_account?.account_identifier || trade.exchange_account_id,
-                        10
-                      )}
-                    </span>
-                  </div>
-                </TableCell>
+              className={cn(
+                isNewItem?.(trade.id) && "animate-highlight-new"
               )}
-              <TableCell className="font-medium">
+            >
+              <TableCell className="py-3 pl-0">
+                <div className="flex">
+                  <div
+                    className={cn(
+                      "w-1 self-stretch rounded-full mr-3 flex-shrink-0",
+                      trade.side === "buy" ? "bg-green-500" : "bg-red-500"
+                    )}
+                  />
+                  <div className="flex flex-col">
+                    <span className="text-sm">
+                      {formatTimestamp(trade.timestamp)}
+                    </span>
+                    {showAccount && (
+                      <div className="flex items-center gap-1 mt-0.5 text-muted-foreground">
+                        <span className="text-xs">
+                          {trade.exchange_account?.exchange?.display_name || "Unknown"}
+                        </span>
+                        <span className="text-xs font-mono">
+                          ({trade.exchange_account?.account_identifier || trade.exchange_account_id})
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell className="py-3 font-medium">
                 {trade.base_asset}/{trade.quote_asset}
               </TableCell>
-              <TableCell>
-                <Badge
-                  variant={trade.side === "buy" ? "default" : "destructive"}
-                  className={
-                    trade.side === "buy"
-                      ? "bg-green-600 hover:bg-green-700"
-                      : ""
-                  }
+              <TableCell className="py-3">
+                <span
+                  className={cn(
+                    "font-medium",
+                    trade.side === "buy" ? "text-green-600" : "text-red-600"
+                  )}
                 >
                   {trade.side.toUpperCase()}
-                </Badge>
+                </span>
               </TableCell>
-              <TableCell className="text-right font-mono">
+              <TableCell className="py-3 text-right font-mono">
                 {formatNumber(trade.price)}
               </TableCell>
-              <TableCell className="text-right font-mono">
+              <TableCell className="py-3 text-right font-mono">
                 {formatNumber(trade.quantity)}
               </TableCell>
-              <TableCell className="text-right font-mono text-muted-foreground">
+              <TableCell className="py-3 text-right font-mono">
                 {formatNumber(trade.fee, 6)}
-              </TableCell>
-              <TableCell className="font-mono text-xs text-muted-foreground">
-                {truncateId(trade.order_id)}
               </TableCell>
             </TableRow>
           ))}


### PR DESCRIPTION
- Remove Order ID column to reduce clutter
- Move account info (exchange name + address) under timestamp
- Add colored indicator bar for buy (green) / sell (red) trades
- Increase row padding for better readability
- Show full account identifier without truncation
- Standardize font colors across columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)