### PR TITLE
Remove created_at field from trades schema

### DIFF
--- a/src/lib/api/mock.ts
+++ b/src/lib/api/mock.ts
@@ -57,7 +57,6 @@ const mockTrades: Trade[] = [
     order_id: "ord-abc123def456",
     trade_id: "trd-001",
     exchange_account_id: "mock-acc-001",
-    created_at: new Date().toISOString(),
     exchange_account: mockAccounts[0],
   },
   {
@@ -72,7 +71,6 @@ const mockTrades: Trade[] = [
     order_id: "ord-xyz789ghi012",
     trade_id: "trd-002",
     exchange_account_id: "mock-acc-001",
-    created_at: new Date().toISOString(),
     exchange_account: mockAccounts[0],
   },
   {
@@ -87,7 +85,6 @@ const mockTrades: Trade[] = [
     order_id: "ord-mno345pqr678",
     trade_id: "trd-003",
     exchange_account_id: "mock-acc-003",
-    created_at: new Date().toISOString(),
     exchange_account: mockAccounts[2],
   },
   {
@@ -102,7 +99,6 @@ const mockTrades: Trade[] = [
     order_id: "ord-stu901vwx234",
     trade_id: "trd-004",
     exchange_account_id: "mock-acc-002",
-    created_at: new Date().toISOString(),
     exchange_account: mockAccounts[1],
   },
   {
@@ -117,7 +113,6 @@ const mockTrades: Trade[] = [
     order_id: "ord-yza567bcd890",
     trade_id: "trd-005",
     exchange_account_id: "mock-acc-001",
-    created_at: new Date().toISOString(),
     exchange_account: mockAccounts[0],
   },
 ];

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -105,7 +105,6 @@ export interface Trade {
   order_id: string;
   trade_id: string;
   exchange_account_id: string;
-  created_at: string;
   exchange_account?: ExchangeAccount;
 }
 
@@ -124,7 +123,6 @@ export const GET_TRADES = gql`
       order_id
       trade_id
       exchange_account_id
-      created_at
       exchange_account {
         id
         account_identifier
@@ -158,7 +156,6 @@ export const GET_TRADES_BY_ACCOUNT = gql`
       order_id
       trade_id
       exchange_account_id
-      created_at
       exchange_account {
         id
         account_identifier


### PR DESCRIPTION
The trades table schema no longer has a created_at column. This removes the field from:
- Trade interface
- GET_TRADES query
- GET_TRADES_BY_ACCOUNT query
- Mock trade data

🤖 Generated with [Claude Code](https://claude.com/claude-code)