### PR TITLE
Add funding payments page with list view and aggregates

### DIFF
--- a/src/app/(dashboard)/accounts/[id]/funding/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/funding/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef, use } from "react";
+import Link from "next/link";
+import { api } from "@/lib/api";
+import { FundingPayment, ExchangeAccount, FundingAggregates } from "@/lib/queries";
+import { FundingTable } from "@/components/funding-table";
+import { SyncButton } from "@/components/sync-button";
+import { useAutoRefresh } from "@/hooks/use-auto-refresh";
+import { useNewItems } from "@/hooks/use-new-items";
+import { useApi } from "@/hooks/use-api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { StatCard, StatsGrid } from "@/components/stat-card";
+import { formatSignedNumber } from "@/lib/format";
+
+const PAGE_SIZE = 100;
+
+interface AccountFundingPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function AccountFundingPage({ params }: AccountFundingPageProps) {
+  const { id } = use(params);
+  const { withErrorReporting } = useApi();
+  const [fundingPayments, setFundingPayments] = useState<FundingPayment[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [account, setAccount] = useState<ExchangeAccount | null>(null);
+  const [aggregates, setAggregates] = useState<FundingAggregates | null>(null);
+  const [isLoadingAggregates, setIsLoadingAggregates] = useState(true);
+
+  const { updateItems: updateNewItems, isNew } = useNewItems<FundingPayment>();
+
+  const pageRef = useRef(page);
+
+  useEffect(() => {
+    pageRef.current = page;
+  }, [page]);
+
+  const fetchAccount = async () => {
+    try {
+      const data = await api.getAccountById(id);
+      setAccount(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const fetchAggregates = useCallback(async () => {
+    setIsLoadingAggregates(true);
+    try {
+      const data = await withErrorReporting(() => api.getFundingAggregatesByAccount(id));
+      setAggregates(data);
+    } catch (error) {
+      console.error("Failed to fetch aggregates:", error);
+    } finally {
+      setIsLoadingAggregates(false);
+    }
+  }, [id, withErrorReporting]);
+
+  const fetchFundingPayments = useCallback(async (pageNum: number) => {
+    setIsLoading(true);
+    try {
+      const data = await withErrorReporting(() => api.getFundingPaymentsByAccount(id, PAGE_SIZE, pageNum * PAGE_SIZE));
+      setFundingPayments(data.fundingPayments);
+      setTotalCount(data.totalCount);
+      updateNewItems(data.fundingPayments);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [id, withErrorReporting]);
+
+  const fetchAllData = useCallback(async () => {
+    await Promise.all([
+      fetchFundingPayments(pageRef.current),
+      fetchAggregates(),
+    ]);
+  }, [fetchFundingPayments, fetchAggregates]);
+
+  const { lastRefreshTime, refresh } = useAutoRefresh(fetchAllData, {
+    interval: 30000,
+  });
+
+  useEffect(() => {
+    fetchAccount();
+    refresh();
+  }, [id]);
+
+  useEffect(() => {
+    refresh();
+  }, [page]);
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  const accountTitle = account
+    ? `${account.exchange?.display_name || "Unknown"} - ${account.account_identifier.slice(0, 10)}...`
+    : "Account";
+
+  const totalAmount = aggregates ? parseFloat(aggregates.totalAmount) : 0;
+  const isPositive = totalAmount >= 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="outline" asChild>
+          <Link href={`/accounts/${id}`}>Back</Link>
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold">Funding Payments</h1>
+          <p className="text-muted-foreground">{accountTitle}</p>
+        </div>
+        <SyncButton
+          lastRefreshTime={lastRefreshTime}
+          onRefresh={refresh}
+          isLoading={isLoading}
+        />
+      </div>
+
+      <StatsGrid>
+        <StatCard
+          title="Total Funding PnL"
+          value={aggregates ? formatSignedNumber(aggregates.totalAmount) : "+0.00"}
+          isLoading={isLoadingAggregates}
+          valueClassName={isPositive ? "text-green-500" : "text-red-500"}
+        />
+        <StatCard
+          title="Total Payments"
+          value={aggregates?.count.toLocaleString() || "0"}
+          isLoading={isLoadingAggregates}
+        />
+      </StatsGrid>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Funding Payments</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <FundingTable
+            fundingPayments={fundingPayments}
+            totalCount={totalCount}
+            page={page}
+            pageSize={PAGE_SIZE}
+            onPageChange={handlePageChange}
+            showAccount={false}
+            isLoading={isLoading}
+            isNewItem={isNew}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/funding/page.tsx
+++ b/src/app/(dashboard)/funding/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { api } from "@/lib/api";
+import { FundingPayment, ExchangeAccount, FundingAggregates } from "@/lib/queries";
+import { FundingTable } from "@/components/funding-table";
+import { AccountFilter } from "@/components/account-filter";
+import { SyncButton } from "@/components/sync-button";
+import { useAutoRefresh } from "@/hooks/use-auto-refresh";
+import { useNewItems } from "@/hooks/use-new-items";
+import { useApi } from "@/hooks/use-api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { StatCard, StatsGrid } from "@/components/stat-card";
+import { formatSignedNumber } from "@/lib/format";
+
+const PAGE_SIZE = 100;
+
+export default function FundingPage() {
+  const { withErrorReporting } = useApi();
+  const [fundingPayments, setFundingPayments] = useState<FundingPayment[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
+  const [selectedAccountId, setSelectedAccountId] = useState<string>("all");
+  const [aggregates, setAggregates] = useState<FundingAggregates | null>(null);
+  const [isLoadingAggregates, setIsLoadingAggregates] = useState(true);
+
+  const { updateItems: updateNewItems, isNew } = useNewItems<FundingPayment>();
+
+  const pageRef = useRef(page);
+  const selectedAccountIdRef = useRef(selectedAccountId);
+
+  useEffect(() => {
+    pageRef.current = page;
+    selectedAccountIdRef.current = selectedAccountId;
+  }, [page, selectedAccountId]);
+
+  const fetchAccounts = async () => {
+    try {
+      const data = await api.getAccounts();
+      setAccounts(data);
+    } catch (error) {
+      console.error("Failed to fetch accounts:", error);
+    }
+  };
+
+  const fetchAggregates = useCallback(async (accountId: string) => {
+    setIsLoadingAggregates(true);
+    try {
+      const data = await withErrorReporting(() =>
+        accountId === "all"
+          ? api.getFundingAggregates()
+          : api.getFundingAggregatesByAccount(accountId)
+      );
+      setAggregates(data);
+    } catch (error) {
+      console.error("Failed to fetch aggregates:", error);
+    } finally {
+      setIsLoadingAggregates(false);
+    }
+  }, [withErrorReporting]);
+
+  const fetchFundingPayments = useCallback(async (pageNum: number, accountId: string) => {
+    setIsLoading(true);
+    try {
+      const data = await withErrorReporting(() =>
+        accountId === "all"
+          ? api.getFundingPayments(PAGE_SIZE, pageNum * PAGE_SIZE)
+          : api.getFundingPaymentsByAccount(accountId, PAGE_SIZE, pageNum * PAGE_SIZE)
+      );
+
+      setFundingPayments(data.fundingPayments);
+      setTotalCount(data.totalCount);
+      updateNewItems(data.fundingPayments);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [withErrorReporting]);
+
+  const fetchAllData = useCallback(async () => {
+    await Promise.all([
+      fetchFundingPayments(pageRef.current, selectedAccountIdRef.current),
+      fetchAggregates(selectedAccountIdRef.current),
+    ]);
+  }, [fetchFundingPayments, fetchAggregates]);
+
+  const { lastRefreshTime, refresh } = useAutoRefresh(fetchAllData, {
+    interval: 30000,
+  });
+
+  useEffect(() => {
+    fetchAccounts();
+    refresh();
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [page, selectedAccountId]);
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleAccountChange = (accountId: string) => {
+    setSelectedAccountId(accountId);
+    setPage(0);
+  };
+
+  const handleRefresh = () => {
+    refresh();
+  };
+
+  const totalAmount = aggregates ? parseFloat(aggregates.totalAmount) : 0;
+  const isPositive = totalAmount >= 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <div>
+          <h1 className="text-3xl font-bold">Funding Payments</h1>
+          <p className="text-muted-foreground">
+            View funding payments across your exchange accounts
+          </p>
+        </div>
+        <SyncButton
+          lastRefreshTime={lastRefreshTime}
+          onRefresh={handleRefresh}
+          isLoading={isLoading}
+        />
+      </div>
+
+      <StatsGrid>
+        <StatCard
+          title="Total Funding PnL"
+          value={aggregates ? formatSignedNumber(aggregates.totalAmount) : "+0.00"}
+          isLoading={isLoadingAggregates}
+          valueClassName={isPositive ? "text-green-500" : "text-red-500"}
+        />
+        <StatCard
+          title="Total Payments"
+          value={aggregates?.count.toLocaleString() || "0"}
+          isLoading={isLoadingAggregates}
+        />
+      </StatsGrid>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle>
+            {selectedAccountId === "all" ? "All Funding Payments" : "Filtered Payments"}
+          </CardTitle>
+          <AccountFilter
+            accounts={accounts}
+            selectedAccountId={selectedAccountId}
+            onAccountChange={handleAccountChange}
+          />
+        </CardHeader>
+        <CardContent>
+          <FundingTable
+            fundingPayments={fundingPayments}
+            totalCount={totalCount}
+            page={page}
+            pageSize={PAGE_SIZE}
+            onPageChange={handlePageChange}
+            showAccount={true}
+            isLoading={isLoading}
+            isNewItem={isNew}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 const navigation = [
   { name: "Accounts", href: "/accounts" },
   { name: "Trades", href: "/trades" },
+  { name: "Funding", href: "/funding" },
 ];
 
 export default function DashboardLayout({

--- a/src/components/account-detail.tsx
+++ b/src/components/account-detail.tsx
@@ -165,9 +165,12 @@ export function AccountDetail({ accountId }: AccountDetailProps) {
                 </div>
               )}
           </div>
-          <div className="pt-4">
+          <div className="pt-4 flex gap-2">
             <Button asChild>
               <Link href={`/accounts/${accountId}/trades`}>View Trades</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href={`/accounts/${accountId}/funding`}>View Funding</Link>
             </Button>
           </div>
         </CardContent>

--- a/src/components/account-filter.tsx
+++ b/src/components/account-filter.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ExchangeAccount } from "@/lib/queries";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface AccountFilterProps {
+  accounts: ExchangeAccount[];
+  selectedAccountId: string;
+  onAccountChange: (accountId: string) => void;
+  className?: string;
+}
+
+export function AccountFilter({
+  accounts,
+  selectedAccountId,
+  onAccountChange,
+  className = "w-[280px]",
+}: AccountFilterProps) {
+  return (
+    <Select value={selectedAccountId} onValueChange={onAccountChange}>
+      <SelectTrigger className={className}>
+        <SelectValue placeholder="Filter by account" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All Accounts</SelectItem>
+        {accounts.map((account) => (
+          <SelectItem key={account.id} value={account.id}>
+            {account.exchange?.display_name || "Unknown"} - {account.account_identifier.slice(0, 10)}...
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/funding-table.tsx
+++ b/src/components/funding-table.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { FundingPayment } from "@/lib/queries";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { FundingTableSkeleton } from "@/components/table-skeleton";
+import { formatTimestamp, formatSignedNumber } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+interface FundingTableProps {
+  fundingPayments: FundingPayment[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  showAccount?: boolean;
+  isLoading?: boolean;
+  isNewItem?: (id: string) => boolean;
+}
+
+export function FundingTable({
+  fundingPayments,
+  totalCount,
+  page,
+  pageSize,
+  onPageChange,
+  showAccount = false,
+  isLoading = false,
+  isNewItem,
+}: FundingTableProps) {
+  const totalPages = Math.ceil(totalCount / pageSize);
+  const startItem = page * pageSize + 1;
+  const endItem = Math.min((page + 1) * pageSize, totalCount);
+
+  if (isLoading && fundingPayments.length === 0) {
+    return <FundingTableSkeleton rows={5} showAccount={showAccount} />;
+  }
+
+  if (fundingPayments.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <p className="text-muted-foreground mb-2">No funding payments found</p>
+        <p className="text-sm text-muted-foreground">
+          Funding payments will appear here once they are recorded
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Time</TableHead>
+            <TableHead>Asset Pair</TableHead>
+            <TableHead className="text-right">Amount</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {fundingPayments.map((payment) => {
+            const amount = parseFloat(payment.amount);
+            const isPositive = amount >= 0;
+
+            return (
+              <TableRow
+                key={payment.id}
+                className={cn(
+                  isNewItem?.(payment.id) && "animate-highlight-new"
+                )}
+              >
+                <TableCell className="py-3 pl-0">
+                  <div className="flex">
+                    <div
+                      className={cn(
+                        "w-1 self-stretch rounded-full mr-3 flex-shrink-0",
+                        isPositive ? "bg-green-500" : "bg-red-500"
+                      )}
+                    />
+                    <div className="flex flex-col">
+                      <span className="text-sm">
+                        {formatTimestamp(payment.timestamp)}
+                      </span>
+                      {showAccount && (
+                        <div className="flex items-center gap-1 mt-0.5 text-muted-foreground">
+                          <span className="text-xs">
+                            {payment.exchange_account?.exchange?.display_name || "Unknown"}
+                          </span>
+                          <span className="text-xs font-mono">
+                            ({payment.exchange_account?.account_identifier || payment.exchange_account_id})
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell className="py-3 font-medium">
+                  {payment.base_asset}-{payment.quote_asset}
+                </TableCell>
+                <TableCell
+                  className={cn(
+                    "py-3 text-right font-mono",
+                    isPositive ? "text-green-600" : "text-red-600"
+                  )}
+                >
+                  {formatSignedNumber(payment.amount)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Showing {startItem} to {endItem} of {totalCount} funding payments
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(page - 1)}
+            disabled={page === 0}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page {page + 1} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(page + 1)}
+            disabled={page >= totalPages - 1}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/table-skeleton.tsx
+++ b/src/components/table-skeleton.tsx
@@ -73,3 +73,19 @@ export function TradesTableSkeleton({
 
   return <TableSkeleton rows={rows} columns={6} columnWidths={widths} />;
 }
+
+// Pre-configured skeleton for funding payments table (3 columns: Time, Asset Pair, Amount)
+export function FundingTableSkeleton({
+  rows = 5,
+  showAccount = false,
+}: {
+  rows?: number;
+  showAccount?: boolean;
+}) {
+  // Time column is wider when showing account info underneath
+  const widths = showAccount
+    ? ["w-40", "w-24", "w-20"]
+    : ["w-32", "w-24", "w-20"];
+
+  return <TableSkeleton rows={rows} columns={3} columnWidths={widths} />;
+}

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -13,13 +13,21 @@ import {
   GET_TRADES_COUNT_BY_ACCOUNT,
   GET_TRADES_AGGREGATES,
   GET_TRADES_AGGREGATES_BY_ACCOUNT,
+  GET_FUNDING_PAYMENTS,
+  GET_FUNDING_PAYMENTS_BY_ACCOUNT,
+  GET_FUNDING_PAYMENTS_COUNT,
+  GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT,
+  GET_FUNDING_AGGREGATES,
+  GET_FUNDING_AGGREGATES_BY_ACCOUNT,
   Exchange,
   ExchangeAccount,
   ExchangeAccountType,
   Trade,
   TradesAggregates,
+  FundingPayment,
+  FundingAggregates,
 } from "../queries";
-import { ApiClient, CreateAccountInput, TradesResult } from "./types";
+import { ApiClient, CreateAccountInput, TradesResult, FundingPaymentsResult } from "./types";
 import { ApiError } from "./errors";
 
 function isAuthError(error: unknown): boolean {
@@ -195,6 +203,88 @@ export const graphqlApi: ApiClient = {
         totalFees: data.trades_aggregate.aggregate.sum.fee || "0",
         totalVolume: "0",
         count: data.trades_aggregate.aggregate.count,
+      };
+    });
+  },
+
+  async getFundingPayments(limit: number, offset: number): Promise<FundingPaymentsResult> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+
+      const [fundingData, countData] = await Promise.all([
+        client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS, { limit, offset }),
+        client.request<{
+          funding_payments_aggregate: { aggregate: { count: number } };
+        }>(GET_FUNDING_PAYMENTS_COUNT),
+      ]);
+
+      return {
+        fundingPayments: fundingData.funding_payments,
+        totalCount: countData.funding_payments_aggregate.aggregate.count,
+      };
+    });
+  },
+
+  async getFundingPaymentsByAccount(
+    accountId: string,
+    limit: number,
+    offset: number
+  ): Promise<FundingPaymentsResult> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+
+      const [fundingData, countData] = await Promise.all([
+        client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_BY_ACCOUNT, {
+          accountId,
+          limit,
+          offset,
+        }),
+        client.request<{
+          funding_payments_aggregate: { aggregate: { count: number } };
+        }>(GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT, { accountId }),
+      ]);
+
+      return {
+        fundingPayments: fundingData.funding_payments,
+        totalCount: countData.funding_payments_aggregate.aggregate.count,
+      };
+    });
+  },
+
+  async getFundingAggregates(): Promise<FundingAggregates> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+      const data = await client.request<{
+        funding_payments_aggregate: {
+          aggregate: {
+            count: number;
+            sum: { amount: string | null };
+          };
+        };
+      }>(GET_FUNDING_AGGREGATES);
+
+      return {
+        totalAmount: data.funding_payments_aggregate.aggregate.sum.amount || "0",
+        count: data.funding_payments_aggregate.aggregate.count,
+      };
+    });
+  },
+
+  async getFundingAggregatesByAccount(accountId: string): Promise<FundingAggregates> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+      const data = await client.request<{
+        funding_payments_aggregate: {
+          aggregate: {
+            count: number;
+            sum: { amount: string | null };
+          };
+        };
+      }>(GET_FUNDING_AGGREGATES_BY_ACCOUNT, { accountId });
+
+      return {
+        totalAmount: data.funding_payments_aggregate.aggregate.sum.amount || "0",
+        count: data.funding_payments_aggregate.aggregate.count,
       };
     });
   },

--- a/src/lib/api/mock.ts
+++ b/src/lib/api/mock.ts
@@ -1,5 +1,5 @@
-import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates } from "../queries";
-import { ApiClient, CreateAccountInput, TradesResult } from "./types";
+import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates } from "../queries";
+import { ApiClient, CreateAccountInput, TradesResult, FundingPaymentsResult } from "./types";
 
 // Mock exchanges
 const mockExchanges: Exchange[] = [
@@ -114,6 +114,70 @@ const mockTrades: Trade[] = [
     trade_id: "trd-005",
     exchange_account_id: "mock-acc-001",
     exchange_account: mockAccounts[0],
+  },
+];
+
+// Mock funding payments (timestamp is Unix milliseconds)
+const mockFundingPayments: FundingPayment[] = [
+  {
+    id: "mock-funding-001",
+    base_asset: "ETH",
+    quote_asset: "USDC",
+    amount: "12.50",
+    timestamp: Date.now() - 1000 * 60 * 60 * 8,
+    payment_id: "funding-payment-001",
+    exchange_account_id: "mock-acc-001",
+    exchange_account: mockAccounts[0],
+  },
+  {
+    id: "mock-funding-002",
+    base_asset: "BTC",
+    quote_asset: "USDC",
+    amount: "-8.75",
+    timestamp: Date.now() - 1000 * 60 * 60 * 16,
+    payment_id: "funding-payment-002",
+    exchange_account_id: "mock-acc-001",
+    exchange_account: mockAccounts[0],
+  },
+  {
+    id: "mock-funding-003",
+    base_asset: "SOL",
+    quote_asset: "USDC",
+    amount: "5.25",
+    timestamp: Date.now() - 1000 * 60 * 60 * 24,
+    payment_id: "funding-payment-003",
+    exchange_account_id: "mock-acc-002",
+    exchange_account: mockAccounts[1],
+  },
+  {
+    id: "mock-funding-004",
+    base_asset: "ETH",
+    quote_asset: "USDT",
+    amount: "-3.10",
+    timestamp: Date.now() - 1000 * 60 * 60 * 32,
+    payment_id: "funding-payment-004",
+    exchange_account_id: "mock-acc-003",
+    exchange_account: mockAccounts[2],
+  },
+  {
+    id: "mock-funding-005",
+    base_asset: "BTC",
+    quote_asset: "USDC",
+    amount: "22.00",
+    timestamp: Date.now() - 1000 * 60 * 60 * 40,
+    payment_id: "funding-payment-005",
+    exchange_account_id: "mock-acc-001",
+    exchange_account: mockAccounts[0],
+  },
+  {
+    id: "mock-funding-006",
+    base_asset: "ARB",
+    quote_asset: "USDC",
+    amount: "1.50",
+    timestamp: Date.now() - 1000 * 60 * 60 * 48,
+    payment_id: "funding-payment-006",
+    exchange_account_id: "mock-acc-002",
+    exchange_account: mockAccounts[1],
   },
 ];
 
@@ -233,6 +297,58 @@ export const mockApi: ApiClient = {
       totalFees: totalFees.toString(),
       totalVolume: "0",
       count: accountTrades.length,
+    };
+  },
+
+  async getFundingPayments(limit: number, offset: number): Promise<FundingPaymentsResult> {
+    await delay(300);
+    const paginatedPayments = mockFundingPayments.slice(offset, offset + limit);
+    return {
+      fundingPayments: paginatedPayments,
+      totalCount: mockFundingPayments.length,
+    };
+  },
+
+  async getFundingPaymentsByAccount(
+    accountId: string,
+    limit: number,
+    offset: number
+  ): Promise<FundingPaymentsResult> {
+    await delay(300);
+    const accountPayments = mockFundingPayments.filter(
+      (payment) => payment.exchange_account_id === accountId
+    );
+    const paginatedPayments = accountPayments.slice(offset, offset + limit);
+    return {
+      fundingPayments: paginatedPayments,
+      totalCount: accountPayments.length,
+    };
+  },
+
+  async getFundingAggregates(): Promise<FundingAggregates> {
+    await delay(200);
+    const totalAmount = mockFundingPayments.reduce(
+      (sum, payment) => sum + parseFloat(payment.amount),
+      0
+    );
+    return {
+      totalAmount: totalAmount.toString(),
+      count: mockFundingPayments.length,
+    };
+  },
+
+  async getFundingAggregatesByAccount(accountId: string): Promise<FundingAggregates> {
+    await delay(200);
+    const accountPayments = mockFundingPayments.filter(
+      (payment) => payment.exchange_account_id === accountId
+    );
+    const totalAmount = accountPayments.reduce(
+      (sum, payment) => sum + parseFloat(payment.amount),
+      0
+    );
+    return {
+      totalAmount: totalAmount.toString(),
+      count: accountPayments.length,
     };
   },
 };

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,4 +1,4 @@
-import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates } from "../queries";
+import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates } from "../queries";
 
 export interface CreateAccountInput {
   exchange_id: string;
@@ -9,6 +9,11 @@ export interface CreateAccountInput {
 
 export interface TradesResult {
   trades: Trade[];
+  totalCount: number;
+}
+
+export interface FundingPaymentsResult {
+  fundingPayments: FundingPayment[];
   totalCount: number;
 }
 
@@ -27,4 +32,12 @@ export interface ApiClient {
   ): Promise<TradesResult>;
   getTradesAggregates(): Promise<TradesAggregates>;
   getTradesAggregatesByAccount(accountId: string): Promise<TradesAggregates>;
+  getFundingPayments(limit: number, offset: number): Promise<FundingPaymentsResult>;
+  getFundingPaymentsByAccount(
+    accountId: string,
+    limit: number,
+    offset: number
+  ): Promise<FundingPaymentsResult>;
+  getFundingAggregates(): Promise<FundingAggregates>;
+  getFundingAggregatesByAccount(accountId: string): Promise<FundingAggregates>;
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,33 @@
+export function formatNumber(value: string, decimals: number = 4): string {
+  const num = parseFloat(value);
+  if (isNaN(num)) return value;
+  return num.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  });
+}
+
+export function formatSignedNumber(value: string, decimals: number = 2): string {
+  const num = parseFloat(value);
+  if (isNaN(num)) return value;
+  const sign = num >= 0 ? "+" : "";
+  return sign + num.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+export function formatPercentage(value: string, decimals: number = 4): string {
+  const num = parseFloat(value);
+  if (isNaN(num)) return value;
+  const percentage = num * 100;
+  const sign = percentage >= 0 ? "+" : "";
+  return sign + percentage.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }) + "%";
+}
+
+export function formatTimestamp(timestamp: string | number): string {
+  return new Date(timestamp).toLocaleString();
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -223,3 +223,122 @@ export const GET_TRADES_AGGREGATES_BY_ACCOUNT = gql`
     }
   }
 `;
+
+// Funding payment types
+export interface FundingPayment {
+  id: string;
+  base_asset: string;
+  quote_asset: string;
+  amount: string;
+  timestamp: number; // Unix milliseconds (BIGINT)
+  payment_id: string;
+  exchange_account_id: string;
+  exchange_account?: ExchangeAccount;
+}
+
+// Funding payment queries
+export const GET_FUNDING_PAYMENTS = gql`
+  query GetFundingPayments($limit: Int!, $offset: Int!) {
+    funding_payments(limit: $limit, offset: $offset, order_by: { timestamp: desc }) {
+      id
+      base_asset
+      quote_asset
+      amount
+      timestamp
+      payment_id
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+  }
+`;
+
+export const GET_FUNDING_PAYMENTS_BY_ACCOUNT = gql`
+  query GetFundingPaymentsByAccount($accountId: uuid!, $limit: Int!, $offset: Int!) {
+    funding_payments(
+      where: { exchange_account_id: { _eq: $accountId } }
+      limit: $limit
+      offset: $offset
+      order_by: { timestamp: desc }
+    ) {
+      id
+      base_asset
+      quote_asset
+      amount
+      timestamp
+      payment_id
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+  }
+`;
+
+export const GET_FUNDING_PAYMENTS_COUNT = gql`
+  query GetFundingPaymentsCount {
+    funding_payments_aggregate {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export const GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT = gql`
+  query GetFundingPaymentsCountByAccount($accountId: uuid!) {
+    funding_payments_aggregate(where: { exchange_account_id: { _eq: $accountId } }) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+// Funding aggregates interface
+export interface FundingAggregates {
+  totalAmount: string;
+  count: number;
+}
+
+// Funding aggregate queries
+export const GET_FUNDING_AGGREGATES = gql`
+  query GetFundingAggregates {
+    funding_payments_aggregate {
+      aggregate {
+        count
+        sum {
+          amount
+        }
+      }
+    }
+  }
+`;
+
+export const GET_FUNDING_AGGREGATES_BY_ACCOUNT = gql`
+  query GetFundingAggregatesByAccount($accountId: uuid!) {
+    funding_payments_aggregate(where: { exchange_account_id: { _eq: $accountId } }) {
+      aggregate {
+        count
+        sum {
+          amount
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
- Add FundingPayment type and GraphQL queries for funding payments
- Create funding payments list page at /funding with pagination
- Create per-account funding view at /accounts/[id]/funding
- Add FundingTable component with asset pair display (base_asset-quote_asset)
- Add funding aggregates (total amount, count) to API
- Add navigation link to Funding in dashboard layout
- Add "View Funding" button to account detail page
- Update mock API with sample funding payment data

🤖 Generated with [Claude Code](https://claude.com/claude-code)