### PR TITLE
Refactor trades and funding pages to use shared usePaginatedData hook

### DIFF
--- a/src/app/(dashboard)/accounts/[id]/funding/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/funding/page.tsx
@@ -1,21 +1,41 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, use } from "react";
+import { useState, useEffect, use } from "react";
 import Link from "next/link";
 import { api } from "@/lib/api";
 import { FundingPayment, ExchangeAccount, FundingAggregates } from "@/lib/queries";
 import { FundingTable } from "@/components/funding-table";
 import { SyncButton } from "@/components/sync-button";
-import { useAutoRefresh } from "@/hooks/use-auto-refresh";
-import { useNewItems } from "@/hooks/use-new-items";
-import { useApi } from "@/hooks/use-api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { StatCard, StatsGrid } from "@/components/stat-card";
 import { formatSignedNumber } from "@/lib/format";
-import { DateRangeFilter, DateRangeValue, getTimestampFromDateRange } from "@/components/date-range-filter";
+import { DateRangeFilter } from "@/components/date-range-filter";
+import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
+
+async function fetchFundingPayments(
+  limit: number,
+  offset: number,
+  accountId: string | undefined,
+  since: number | undefined
+) {
+  const data = accountId
+    ? await api.getFundingPaymentsByAccount(accountId, limit, offset, since)
+    : await api.getFundingPayments(limit, offset, since);
+
+  return { items: data.fundingPayments, totalCount: data.totalCount };
+}
+
+async function fetchFundingAggregates(
+  accountId: string | undefined,
+  since: number | undefined
+) {
+  return accountId
+    ? api.getFundingAggregatesByAccount(accountId, since)
+    : api.getFundingAggregates(since);
+}
 
 interface AccountFundingPageProps {
   params: Promise<{ id: string }>;
@@ -23,91 +43,39 @@ interface AccountFundingPageProps {
 
 export default function AccountFundingPage({ params }: AccountFundingPageProps) {
   const { id } = use(params);
-  const { withErrorReporting } = useApi();
-  const [fundingPayments, setFundingPayments] = useState<FundingPayment[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
-  const [page, setPage] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [account, setAccount] = useState<ExchangeAccount | null>(null);
-  const [aggregates, setAggregates] = useState<FundingAggregates | null>(null);
-  const [isLoadingAggregates, setIsLoadingAggregates] = useState(true);
-  const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
 
-  const { updateItems: updateNewItems, isNew } = useNewItems<FundingPayment>();
-
-  const pageRef = useRef(page);
-  const dateRangeRef = useRef(dateRange);
-
-  useEffect(() => {
-    pageRef.current = page;
-    dateRangeRef.current = dateRange;
-  }, [page, dateRange]);
-
-  const fetchAccount = async () => {
-    try {
-      const data = await api.getAccountById(id);
-      setAccount(data);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const fetchAggregates = useCallback(async (dateRangeValue: DateRangeValue) => {
-    setIsLoadingAggregates(true);
-    const since = getTimestampFromDateRange(dateRangeValue);
-    try {
-      const data = await withErrorReporting(() => api.getFundingAggregatesByAccount(id, since));
-      setAggregates(data);
-    } catch (error) {
-      console.error("Failed to fetch aggregates:", error);
-    } finally {
-      setIsLoadingAggregates(false);
-    }
-  }, [id, withErrorReporting]);
-
-  const fetchFundingPayments = useCallback(async (pageNum: number, dateRangeValue: DateRangeValue) => {
-    setIsLoading(true);
-    const since = getTimestampFromDateRange(dateRangeValue);
-    try {
-      const data = await withErrorReporting(() => api.getFundingPaymentsByAccount(id, PAGE_SIZE, pageNum * PAGE_SIZE, since));
-      setFundingPayments(data.fundingPayments);
-      setTotalCount(data.totalCount);
-      updateNewItems(data.fundingPayments);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, withErrorReporting]);
-
-  const fetchAllData = useCallback(async () => {
-    await Promise.all([
-      fetchFundingPayments(pageRef.current, dateRangeRef.current),
-      fetchAggregates(dateRangeRef.current),
-    ]);
-  }, [fetchFundingPayments, fetchAggregates]);
-
-  const { lastRefreshTime, refresh } = useAutoRefresh(fetchAllData, {
-    interval: 30000,
+  const {
+    items: fundingPayments,
+    totalCount,
+    aggregates,
+    isLoading,
+    isLoadingAggregates,
+    page,
+    dateRange,
+    isNew,
+    handlePageChange,
+    handleDateRangeChange,
+    refresh,
+    lastRefreshTime,
+  } = usePaginatedData<FundingPayment, FundingAggregates>({
+    fetchItems: fetchFundingPayments,
+    fetchAggregates: fetchFundingAggregates,
+    accountId: id,
+    pageSize: PAGE_SIZE,
   });
 
   useEffect(() => {
+    const fetchAccount = async () => {
+      try {
+        const data = await api.getAccountById(id);
+        setAccount(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
     fetchAccount();
-    refresh();
   }, [id]);
-
-  useEffect(() => {
-    refresh();
-  }, [page, dateRange]);
-
-  const handlePageChange = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const handleDateRangeChange = (newRange: DateRangeValue) => {
-    setDateRange(newRange);
-    setPage(0);
-  };
 
   const accountTitle = account
     ? `${account.exchange?.display_name || "Unknown"} - ${account.account_identifier.slice(0, 10)}...`

--- a/src/app/(dashboard)/accounts/[id]/trades/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/trades/page.tsx
@@ -1,20 +1,40 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, use } from "react";
+import { useState, useEffect, use } from "react";
 import Link from "next/link";
 import { api } from "@/lib/api";
 import { Trade, ExchangeAccount, TradesAggregates } from "@/lib/queries";
 import { TradesTable } from "@/components/trades-table";
 import { SyncButton } from "@/components/sync-button";
-import { useAutoRefresh } from "@/hooks/use-auto-refresh";
-import { useNewItems } from "@/hooks/use-new-items";
-import { useApi } from "@/hooks/use-api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { StatCard, StatsGrid } from "@/components/stat-card";
-import { DateRangeFilter, DateRangeValue, getTimestampFromDateRange } from "@/components/date-range-filter";
+import { DateRangeFilter } from "@/components/date-range-filter";
+import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
+
+async function fetchTrades(
+  limit: number,
+  offset: number,
+  accountId: string | undefined,
+  since: number | undefined
+) {
+  const data = accountId
+    ? await api.getTradesByAccount(accountId, limit, offset, since)
+    : await api.getTrades(limit, offset, since);
+
+  return { items: data.trades, totalCount: data.totalCount };
+}
+
+async function fetchTradesAggregates(
+  accountId: string | undefined,
+  since: number | undefined
+) {
+  return accountId
+    ? api.getTradesAggregatesByAccount(accountId, since)
+    : api.getTradesAggregates(since);
+}
 
 interface AccountTradesPageProps {
   params: Promise<{ id: string }>;
@@ -22,99 +42,43 @@ interface AccountTradesPageProps {
 
 export default function AccountTradesPage({ params }: AccountTradesPageProps) {
   const { id } = use(params);
-  const { withErrorReporting } = useApi();
-  const [trades, setTrades] = useState<Trade[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
-  const [page, setPage] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [account, setAccount] = useState<ExchangeAccount | null>(null);
-  const [aggregates, setAggregates] = useState<TradesAggregates | null>(null);
-  const [isLoadingAggregates, setIsLoadingAggregates] = useState(true);
-  const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
 
-  // Track new items for highlighting
-  const { updateItems: updateNewItems, isNew } = useNewItems<Trade>();
-
-  // Use refs to track current values for auto-refresh
-  const pageRef = useRef(page);
-  const dateRangeRef = useRef(dateRange);
-
-  useEffect(() => {
-    pageRef.current = page;
-    dateRangeRef.current = dateRange;
-  }, [page, dateRange]);
-
-  const fetchAccount = async () => {
-    try {
-      const data = await api.getAccountById(id);
-      setAccount(data);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const fetchAggregates = useCallback(async (dateRangeValue: DateRangeValue) => {
-    setIsLoadingAggregates(true);
-    const since = getTimestampFromDateRange(dateRangeValue);
-    try {
-      const data = await withErrorReporting(() => api.getTradesAggregatesByAccount(id, since));
-      setAggregates(data);
-    } catch (error) {
-      console.error("Failed to fetch aggregates:", error);
-    } finally {
-      setIsLoadingAggregates(false);
-    }
-  }, [id, withErrorReporting]);
-
-  const fetchTrades = useCallback(async (pageNum: number, dateRangeValue: DateRangeValue) => {
-    setIsLoading(true);
-    const since = getTimestampFromDateRange(dateRangeValue);
-    try {
-      const data = await withErrorReporting(() => api.getTradesByAccount(id, PAGE_SIZE, pageNum * PAGE_SIZE, since));
-      setTrades(data.trades);
-      setTotalCount(data.totalCount);
-      updateNewItems(data.trades);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, withErrorReporting]);
-
-  // Fetch function for auto-refresh
-  const fetchAllData = useCallback(async () => {
-    await Promise.all([
-      fetchTrades(pageRef.current, dateRangeRef.current),
-      fetchAggregates(dateRangeRef.current),
-    ]);
-  }, [fetchTrades, fetchAggregates]);
-
-  const { lastRefreshTime, refresh } = useAutoRefresh(fetchAllData, {
-    interval: 30000,
+  const {
+    items: trades,
+    totalCount,
+    aggregates,
+    isLoading,
+    isLoadingAggregates,
+    page,
+    dateRange,
+    isNew,
+    handlePageChange,
+    handleDateRangeChange,
+    refresh,
+    lastRefreshTime,
+  } = usePaginatedData<Trade, TradesAggregates>({
+    fetchItems: fetchTrades,
+    fetchAggregates: fetchTradesAggregates,
+    accountId: id,
+    pageSize: PAGE_SIZE,
   });
 
   useEffect(() => {
+    const fetchAccount = async () => {
+      try {
+        const data = await api.getAccountById(id);
+        setAccount(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
     fetchAccount();
-    refresh(); // Initial fetch through auto-refresh to set lastRefreshTime
   }, [id]);
-
-  // Refetch when page or date range changes
-  useEffect(() => {
-    refresh();
-  }, [page, dateRange]);
 
   const formatFees = (value: string) => {
     const num = parseFloat(value);
     return num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 });
-  };
-
-  const handlePageChange = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const handleDateRangeChange = (newRange: DateRangeValue) => {
-    setDateRange(newRange);
-    setPage(0);
   };
 
   const accountTitle = account

--- a/src/app/(dashboard)/funding/page.tsx
+++ b/src/app/(dashboard)/funding/page.tsx
@@ -1,128 +1,76 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect } from "react";
 import { api } from "@/lib/api";
 import { FundingPayment, ExchangeAccount, FundingAggregates } from "@/lib/queries";
 import { FundingTable } from "@/components/funding-table";
 import { AccountFilter } from "@/components/account-filter";
 import { SyncButton } from "@/components/sync-button";
-import { useAutoRefresh } from "@/hooks/use-auto-refresh";
-import { useNewItems } from "@/hooks/use-new-items";
-import { useApi } from "@/hooks/use-api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatCard, StatsGrid } from "@/components/stat-card";
 import { formatSignedNumber } from "@/lib/format";
-import { DateRangeFilter, DateRangeValue, getTimestampFromDateRange } from "@/components/date-range-filter";
+import { DateRangeFilter } from "@/components/date-range-filter";
+import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
 
+async function fetchFundingPayments(
+  limit: number,
+  offset: number,
+  accountId: string | undefined,
+  since: number | undefined
+) {
+  const data = accountId
+    ? await api.getFundingPaymentsByAccount(accountId, limit, offset, since)
+    : await api.getFundingPayments(limit, offset, since);
+
+  return { items: data.fundingPayments, totalCount: data.totalCount };
+}
+
+async function fetchFundingAggregates(
+  accountId: string | undefined,
+  since: number | undefined
+) {
+  return accountId
+    ? api.getFundingAggregatesByAccount(accountId, since)
+    : api.getFundingAggregates(since);
+}
+
 export default function FundingPage() {
-  const { withErrorReporting } = useApi();
-  const [fundingPayments, setFundingPayments] = useState<FundingPayment[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
-  const [page, setPage] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
-  const [selectedAccountId, setSelectedAccountId] = useState<string>("all");
-  const [aggregates, setAggregates] = useState<FundingAggregates | null>(null);
-  const [isLoadingAggregates, setIsLoadingAggregates] = useState(true);
-  const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
 
-  const { updateItems: updateNewItems, isNew } = useNewItems<FundingPayment>();
-
-  const pageRef = useRef(page);
-  const selectedAccountIdRef = useRef(selectedAccountId);
-  const dateRangeRef = useRef(dateRange);
-
-  useEffect(() => {
-    pageRef.current = page;
-    selectedAccountIdRef.current = selectedAccountId;
-    dateRangeRef.current = dateRange;
-  }, [page, selectedAccountId, dateRange]);
-
-  const fetchAccounts = async () => {
-    try {
-      const data = await api.getAccounts();
-      setAccounts(data);
-    } catch (error) {
-      console.error("Failed to fetch accounts:", error);
-    }
-  };
-
-  const fetchAggregates = useCallback(async (accountId: string, dateRangeValue: DateRangeValue) => {
-    setIsLoadingAggregates(true);
-    const since = getTimestampFromDateRange(dateRangeValue);
-    try {
-      const data = await withErrorReporting(() =>
-        accountId === "all"
-          ? api.getFundingAggregates(since)
-          : api.getFundingAggregatesByAccount(accountId, since)
-      );
-      setAggregates(data);
-    } catch (error) {
-      console.error("Failed to fetch aggregates:", error);
-    } finally {
-      setIsLoadingAggregates(false);
-    }
-  }, [withErrorReporting]);
-
-  const fetchFundingPayments = useCallback(async (pageNum: number, accountId: string, dateRangeValue: DateRangeValue) => {
-    setIsLoading(true);
-    const since = getTimestampFromDateRange(dateRangeValue);
-    try {
-      const data = await withErrorReporting(() =>
-        accountId === "all"
-          ? api.getFundingPayments(PAGE_SIZE, pageNum * PAGE_SIZE, since)
-          : api.getFundingPaymentsByAccount(accountId, PAGE_SIZE, pageNum * PAGE_SIZE, since)
-      );
-
-      setFundingPayments(data.fundingPayments);
-      setTotalCount(data.totalCount);
-      updateNewItems(data.fundingPayments);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [withErrorReporting]);
-
-  const fetchAllData = useCallback(async () => {
-    await Promise.all([
-      fetchFundingPayments(pageRef.current, selectedAccountIdRef.current, dateRangeRef.current),
-      fetchAggregates(selectedAccountIdRef.current, dateRangeRef.current),
-    ]);
-  }, [fetchFundingPayments, fetchAggregates]);
-
-  const { lastRefreshTime, refresh } = useAutoRefresh(fetchAllData, {
-    interval: 30000,
+  const {
+    items: fundingPayments,
+    totalCount,
+    aggregates,
+    isLoading,
+    isLoadingAggregates,
+    page,
+    selectedAccountId,
+    dateRange,
+    isNew,
+    handlePageChange,
+    handleAccountChange,
+    handleDateRangeChange,
+    refresh,
+    lastRefreshTime,
+  } = usePaginatedData<FundingPayment, FundingAggregates>({
+    fetchItems: fetchFundingPayments,
+    fetchAggregates: fetchFundingAggregates,
+    pageSize: PAGE_SIZE,
   });
 
   useEffect(() => {
+    const fetchAccounts = async () => {
+      try {
+        const data = await api.getAccounts();
+        setAccounts(data);
+      } catch (error) {
+        console.error("Failed to fetch accounts:", error);
+      }
+    };
     fetchAccounts();
-    refresh();
   }, []);
-
-  useEffect(() => {
-    refresh();
-  }, [page, selectedAccountId, dateRange]);
-
-  const handlePageChange = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const handleAccountChange = (accountId: string) => {
-    setSelectedAccountId(accountId);
-    setPage(0);
-  };
-
-  const handleDateRangeChange = (newRange: DateRangeValue) => {
-    setDateRange(newRange);
-    setPage(0);
-  };
-
-  const handleRefresh = () => {
-    refresh();
-  };
 
   const totalAmount = aggregates ? parseFloat(aggregates.totalAmount) : 0;
   const isPositive = totalAmount >= 0;
@@ -138,7 +86,7 @@ export default function FundingPage() {
         </div>
         <SyncButton
           lastRefreshTime={lastRefreshTime}
-          onRefresh={handleRefresh}
+          onRefresh={refresh}
           isLoading={isLoading}
         />
       </div>

--- a/src/app/(dashboard)/trades/page.tsx
+++ b/src/app/(dashboard)/trades/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect } from "react";
 import { api } from "@/lib/api";
 import { Trade, ExchangeAccount, TradesAggregates } from "@/lib/queries";
 import { TradesTable } from "@/components/trades-table";
 import { SyncButton } from "@/components/sync-button";
-import { useAutoRefresh } from "@/hooks/use-auto-refresh";
-import { useNewItems } from "@/hooks/use-new-items";
-import { useApi } from "@/hooks/use-api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatCard, StatsGrid } from "@/components/stat-card";
 import {
@@ -17,121 +14,68 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { DateRangeFilter, DateRangeValue, getTimestampFromDateRange } from "@/components/date-range-filter";
+import { DateRangeFilter } from "@/components/date-range-filter";
+import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
 
+async function fetchTrades(
+  limit: number,
+  offset: number,
+  accountId: string | undefined,
+  since: number | undefined
+) {
+  const data = accountId
+    ? await api.getTradesByAccount(accountId, limit, offset, since)
+    : await api.getTrades(limit, offset, since);
+
+  return { items: data.trades, totalCount: data.totalCount };
+}
+
+async function fetchTradesAggregates(
+  accountId: string | undefined,
+  since: number | undefined
+) {
+  return accountId
+    ? api.getTradesAggregatesByAccount(accountId, since)
+    : api.getTradesAggregates(since);
+}
+
 export default function TradesPage() {
-  const { withErrorReporting } = useApi();
-  const [trades, setTrades] = useState<Trade[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
-  const [page, setPage] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
-  const [selectedAccountId, setSelectedAccountId] = useState<string>("all");
-  const [aggregates, setAggregates] = useState<TradesAggregates | null>(null);
-  const [isLoadingAggregates, setIsLoadingAggregates] = useState(true);
-  const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
 
-  // Track new items for highlighting
-  const { updateItems: updateNewItems, isNew } = useNewItems<Trade>();
-
-  // Use refs to track current values for auto-refresh
-  const pageRef = useRef(page);
-  const selectedAccountIdRef = useRef(selectedAccountId);
-  const dateRangeRef = useRef(dateRange);
-
-  useEffect(() => {
-    pageRef.current = page;
-    selectedAccountIdRef.current = selectedAccountId;
-    dateRangeRef.current = dateRange;
-  }, [page, selectedAccountId, dateRange]);
-
-  const fetchAccounts = async () => {
-    try {
-      const data = await api.getAccounts();
-      setAccounts(data);
-    } catch (error) {
-      console.error("Failed to fetch accounts:", error);
-    }
-  };
-
-  const fetchAggregates = useCallback(async (accountId: string, dateRangeValue: DateRangeValue) => {
-    setIsLoadingAggregates(true);
-    const since = getTimestampFromDateRange(dateRangeValue);
-    try {
-      const data = await withErrorReporting(() =>
-        accountId === "all"
-          ? api.getTradesAggregates(since)
-          : api.getTradesAggregatesByAccount(accountId, since)
-      );
-      setAggregates(data);
-    } catch (error) {
-      console.error("Failed to fetch aggregates:", error);
-    } finally {
-      setIsLoadingAggregates(false);
-    }
-  }, [withErrorReporting]);
-
-  const fetchTrades = useCallback(async (pageNum: number, accountId: string, dateRangeValue: DateRangeValue) => {
-    setIsLoading(true);
-    const since = getTimestampFromDateRange(dateRangeValue);
-    try {
-      const data = await withErrorReporting(() =>
-        accountId === "all"
-          ? api.getTrades(PAGE_SIZE, pageNum * PAGE_SIZE, since)
-          : api.getTradesByAccount(accountId, PAGE_SIZE, pageNum * PAGE_SIZE, since)
-      );
-
-      setTrades(data.trades);
-      setTotalCount(data.totalCount);
-      updateNewItems(data.trades);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [withErrorReporting]);
-
-  // Fetch function for auto-refresh (uses refs for current values)
-  const fetchAllData = useCallback(async () => {
-    await Promise.all([
-      fetchTrades(pageRef.current, selectedAccountIdRef.current, dateRangeRef.current),
-      fetchAggregates(selectedAccountIdRef.current, dateRangeRef.current),
-    ]);
-  }, [fetchTrades, fetchAggregates]);
-
-  const { lastRefreshTime, refresh } = useAutoRefresh(fetchAllData, {
-    interval: 30000,
+  const {
+    items: trades,
+    totalCount,
+    aggregates,
+    isLoading,
+    isLoadingAggregates,
+    page,
+    selectedAccountId,
+    dateRange,
+    isNew,
+    handlePageChange,
+    handleAccountChange,
+    handleDateRangeChange,
+    refresh,
+    lastRefreshTime,
+  } = usePaginatedData<Trade, TradesAggregates>({
+    fetchItems: fetchTrades,
+    fetchAggregates: fetchTradesAggregates,
+    pageSize: PAGE_SIZE,
   });
 
   useEffect(() => {
+    const fetchAccounts = async () => {
+      try {
+        const data = await api.getAccounts();
+        setAccounts(data);
+      } catch (error) {
+        console.error("Failed to fetch accounts:", error);
+      }
+    };
     fetchAccounts();
-    refresh(); // Initial fetch through auto-refresh to set lastRefreshTime
   }, []);
-
-  // Refetch when page, account, or date range changes
-  useEffect(() => {
-    refresh();
-  }, [page, selectedAccountId, dateRange]);
-
-  const handlePageChange = (newPage: number) => {
-    setPage(newPage);
-  };
-
-  const handleAccountChange = (accountId: string) => {
-    setSelectedAccountId(accountId);
-    setPage(0);
-  };
-
-  const handleDateRangeChange = (newRange: DateRangeValue) => {
-    setDateRange(newRange);
-    setPage(0);
-  };
-
-  const handleRefresh = () => {
-    refresh();
-  };
 
   const formatFees = (value: string) => {
     const num = parseFloat(value);
@@ -149,7 +93,7 @@ export default function TradesPage() {
         </div>
         <SyncButton
           lastRefreshTime={lastRefreshTime}
-          onRefresh={handleRefresh}
+          onRefresh={refresh}
           isLoading={isLoading}
         />
       </div>

--- a/src/hooks/use-paginated-data.ts
+++ b/src/hooks/use-paginated-data.ts
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useAutoRefresh } from "@/hooks/use-auto-refresh";
+import { useNewItems } from "@/hooks/use-new-items";
+import { useApi } from "@/hooks/use-api";
+import { DateRangeValue, getTimestampFromDateRange } from "@/components/date-range-filter";
+
+export interface PaginatedResult<T> {
+  items: T[];
+  totalCount: number;
+}
+
+export interface UsePaginatedDataConfig<TItem, TAggregates> {
+  /** Fetch items for the given page, account, and date range */
+  fetchItems: (
+    limit: number,
+    offset: number,
+    accountId: string | undefined,
+    since: number | undefined
+  ) => Promise<PaginatedResult<TItem>>;
+
+  /** Fetch aggregates for the given account and date range */
+  fetchAggregates: (
+    accountId: string | undefined,
+    since: number | undefined
+  ) => Promise<TAggregates>;
+
+  /** Fixed account ID for account-specific pages (undefined for global pages) */
+  accountId?: string;
+
+  /** Page size for pagination */
+  pageSize?: number;
+
+  /** Auto-refresh interval in ms */
+  refreshInterval?: number;
+}
+
+export interface UsePaginatedDataResult<TItem, TAggregates> {
+  // Data
+  items: TItem[];
+  totalCount: number;
+  aggregates: TAggregates | null;
+
+  // Loading states
+  isLoading: boolean;
+  isLoadingAggregates: boolean;
+
+  // Pagination
+  page: number;
+  pageSize: number;
+
+  // Filters
+  selectedAccountId: string;
+  dateRange: DateRangeValue;
+
+  // New item tracking
+  isNew: (id: string) => boolean;
+
+  // Handlers
+  handlePageChange: (newPage: number) => void;
+  handleAccountChange: (accountId: string) => void;
+  handleDateRangeChange: (newRange: DateRangeValue) => void;
+
+  // Refresh
+  refresh: () => void;
+  lastRefreshTime: Date | null;
+}
+
+const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_REFRESH_INTERVAL = 30000;
+
+export function usePaginatedData<TItem extends { id: string }, TAggregates>(
+  config: UsePaginatedDataConfig<TItem, TAggregates>
+): UsePaginatedDataResult<TItem, TAggregates> {
+  const {
+    fetchItems,
+    fetchAggregates,
+    accountId,
+    pageSize = DEFAULT_PAGE_SIZE,
+    refreshInterval = DEFAULT_REFRESH_INTERVAL,
+  } = config;
+
+  const { withErrorReporting } = useApi();
+
+  // Data state
+  const [items, setItems] = useState<TItem[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [aggregates, setAggregates] = useState<TAggregates | null>(null);
+
+  // Loading states
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingAggregates, setIsLoadingAggregates] = useState(true);
+
+  // Pagination and filters
+  const [page, setPage] = useState(0);
+  const [selectedAccountId, setSelectedAccountId] = useState<string>(accountId ?? "all");
+  const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
+
+  // New item tracking
+  const { updateItems: updateNewItems, isNew } = useNewItems<TItem>();
+
+  // Refs for auto-refresh (to avoid stale closures)
+  const pageRef = useRef(page);
+  const selectedAccountIdRef = useRef(selectedAccountId);
+  const dateRangeRef = useRef(dateRange);
+
+  useEffect(() => {
+    pageRef.current = page;
+    selectedAccountIdRef.current = selectedAccountId;
+    dateRangeRef.current = dateRange;
+  }, [page, selectedAccountId, dateRange]);
+
+  // Fetch aggregates
+  const doFetchAggregates = useCallback(
+    async (accId: string, dateRangeValue: DateRangeValue) => {
+      setIsLoadingAggregates(true);
+      const since = getTimestampFromDateRange(dateRangeValue);
+      const effectiveAccountId = accId === "all" ? undefined : accId;
+
+      try {
+        const data = await withErrorReporting(() =>
+          fetchAggregates(effectiveAccountId, since)
+        );
+        setAggregates(data);
+      } catch (error) {
+        console.error("Failed to fetch aggregates:", error);
+      } finally {
+        setIsLoadingAggregates(false);
+      }
+    },
+    [fetchAggregates, withErrorReporting]
+  );
+
+  // Fetch items
+  const doFetchItems = useCallback(
+    async (pageNum: number, accId: string, dateRangeValue: DateRangeValue) => {
+      setIsLoading(true);
+      const since = getTimestampFromDateRange(dateRangeValue);
+      const effectiveAccountId = accId === "all" ? undefined : accId;
+
+      try {
+        const data = await withErrorReporting(() =>
+          fetchItems(pageSize, pageNum * pageSize, effectiveAccountId, since)
+        );
+        setItems(data.items);
+        setTotalCount(data.totalCount);
+        updateNewItems(data.items);
+      } catch (error) {
+        console.error("Failed to fetch items:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [fetchItems, pageSize, withErrorReporting, updateNewItems]
+  );
+
+  // Combined fetch for auto-refresh
+  const fetchAllData = useCallback(async () => {
+    await Promise.all([
+      doFetchItems(pageRef.current, selectedAccountIdRef.current, dateRangeRef.current),
+      doFetchAggregates(selectedAccountIdRef.current, dateRangeRef.current),
+    ]);
+  }, [doFetchItems, doFetchAggregates]);
+
+  // Auto-refresh
+  const { lastRefreshTime, refresh } = useAutoRefresh(fetchAllData, {
+    interval: refreshInterval,
+  });
+
+  // Initial fetch
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  // Refetch when filters change
+  useEffect(() => {
+    refresh();
+  }, [page, selectedAccountId, dateRange]);
+
+  // If accountId prop changes (for account-specific pages), update filter
+  useEffect(() => {
+    if (accountId) {
+      setSelectedAccountId(accountId);
+    }
+  }, [accountId]);
+
+  // Handlers
+  const handlePageChange = useCallback((newPage: number) => {
+    setPage(newPage);
+  }, []);
+
+  const handleAccountChange = useCallback((newAccountId: string) => {
+    setSelectedAccountId(newAccountId);
+    setPage(0);
+  }, []);
+
+  const handleDateRangeChange = useCallback((newRange: DateRangeValue) => {
+    setDateRange(newRange);
+    setPage(0);
+  }, []);
+
+  return {
+    // Data
+    items,
+    totalCount,
+    aggregates,
+
+    // Loading states
+    isLoading,
+    isLoadingAggregates,
+
+    // Pagination
+    page,
+    pageSize,
+
+    // Filters
+    selectedAccountId,
+    dateRange,
+
+    // New item tracking
+    isNew,
+
+    // Handlers
+    handlePageChange,
+    handleAccountChange,
+    handleDateRangeChange,
+
+    // Refresh
+    refresh,
+    lastRefreshTime,
+  };
+}


### PR DESCRIPTION
- Create usePaginatedData hook that encapsulates pagination, filtering, auto-refresh, and new item tracking logic
- Refactor all 4 pages (trades, funding, account trades, account funding) to use the shared hook
- Reduces code duplication by ~180 lines across the pages
- Centralizes logic for easier maintenance and consistent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)