### PR TITLE
Fix custom date range filter to use both from and to dates

### DIFF
--- a/src/app/(dashboard)/accounts/[id]/funding/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/funding/page.tsx
@@ -19,22 +19,24 @@ async function fetchFundingPayments(
   limit: number,
   offset: number,
   accountId: string | undefined,
-  since: number | undefined
+  since: number | undefined,
+  until: number | undefined
 ) {
   const data = accountId
-    ? await api.getFundingPaymentsByAccount(accountId, limit, offset, since)
-    : await api.getFundingPayments(limit, offset, since);
+    ? await api.getFundingPaymentsByAccount(accountId, limit, offset, since, until)
+    : await api.getFundingPayments(limit, offset, since, until);
 
   return { items: data.fundingPayments, totalCount: data.totalCount };
 }
 
 async function fetchFundingAggregates(
   accountId: string | undefined,
-  since: number | undefined
+  since: number | undefined,
+  until: number | undefined
 ) {
   return accountId
-    ? api.getFundingAggregatesByAccount(accountId, since)
-    : api.getFundingAggregates(since);
+    ? api.getFundingAggregatesByAccount(accountId, since, until)
+    : api.getFundingAggregates(since, until);
 }
 
 interface AccountFundingPageProps {

--- a/src/app/(dashboard)/accounts/[id]/trades/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/trades/page.tsx
@@ -18,22 +18,24 @@ async function fetchTrades(
   limit: number,
   offset: number,
   accountId: string | undefined,
-  since: number | undefined
+  since: number | undefined,
+  until: number | undefined
 ) {
   const data = accountId
-    ? await api.getTradesByAccount(accountId, limit, offset, since)
-    : await api.getTrades(limit, offset, since);
+    ? await api.getTradesByAccount(accountId, limit, offset, since, until)
+    : await api.getTrades(limit, offset, since, until);
 
   return { items: data.trades, totalCount: data.totalCount };
 }
 
 async function fetchTradesAggregates(
   accountId: string | undefined,
-  since: number | undefined
+  since: number | undefined,
+  until: number | undefined
 ) {
   return accountId
-    ? api.getTradesAggregatesByAccount(accountId, since)
-    : api.getTradesAggregates(since);
+    ? api.getTradesAggregatesByAccount(accountId, since, until)
+    : api.getTradesAggregates(since, until);
 }
 
 interface AccountTradesPageProps {

--- a/src/app/(dashboard)/funding/page.tsx
+++ b/src/app/(dashboard)/funding/page.tsx
@@ -18,22 +18,24 @@ async function fetchFundingPayments(
   limit: number,
   offset: number,
   accountId: string | undefined,
-  since: number | undefined
+  since: number | undefined,
+  until: number | undefined
 ) {
   const data = accountId
-    ? await api.getFundingPaymentsByAccount(accountId, limit, offset, since)
-    : await api.getFundingPayments(limit, offset, since);
+    ? await api.getFundingPaymentsByAccount(accountId, limit, offset, since, until)
+    : await api.getFundingPayments(limit, offset, since, until);
 
   return { items: data.fundingPayments, totalCount: data.totalCount };
 }
 
 async function fetchFundingAggregates(
   accountId: string | undefined,
-  since: number | undefined
+  since: number | undefined,
+  until: number | undefined
 ) {
   return accountId
-    ? api.getFundingAggregatesByAccount(accountId, since)
-    : api.getFundingAggregates(since);
+    ? api.getFundingAggregatesByAccount(accountId, since, until)
+    : api.getFundingAggregates(since, until);
 }
 
 export default function FundingPage() {

--- a/src/app/(dashboard)/trades/page.tsx
+++ b/src/app/(dashboard)/trades/page.tsx
@@ -23,22 +23,24 @@ async function fetchTrades(
   limit: number,
   offset: number,
   accountId: string | undefined,
-  since: number | undefined
+  since: number | undefined,
+  until: number | undefined
 ) {
   const data = accountId
-    ? await api.getTradesByAccount(accountId, limit, offset, since)
-    : await api.getTrades(limit, offset, since);
+    ? await api.getTradesByAccount(accountId, limit, offset, since, until)
+    : await api.getTrades(limit, offset, since, until);
 
   return { items: data.trades, totalCount: data.totalCount };
 }
 
 async function fetchTradesAggregates(
   accountId: string | undefined,
-  since: number | undefined
+  since: number | undefined,
+  until: number | undefined
 ) {
   return accountId
-    ? api.getTradesAggregatesByAccount(accountId, since)
-    : api.getTradesAggregates(since);
+    ? api.getTradesAggregatesByAccount(accountId, since, until)
+    : api.getTradesAggregates(since, until);
 }
 
 export default function TradesPage() {

--- a/src/components/date-range-filter.tsx
+++ b/src/components/date-range-filter.tsx
@@ -34,12 +34,24 @@ const presets: { value: DateRangePreset; label: string }[] = [
   { value: "all", label: "All" },
 ];
 
-export function getTimestampFromDateRange(value: DateRangeValue): number | undefined {
-  if (value.preset === "all") return undefined;
+export interface DateRangeTimestamps {
+  since?: number;
+  until?: number;
+}
+
+export function getTimestampsFromDateRange(value: DateRangeValue): DateRangeTimestamps {
+  if (value.preset === "all") return {};
 
   if (value.preset === "custom" && value.customRange) {
-    // Return the start of the custom range
-    return value.customRange.from.getTime();
+    // For custom range, return both start and end timestamps
+    // Set end of day for the 'to' date (23:59:59.999)
+    const endOfDay = new Date(value.customRange.to);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    return {
+      since: value.customRange.from.getTime(),
+      until: endOfDay.getTime(),
+    };
   }
 
   const now = Date.now();
@@ -50,7 +62,13 @@ export function getTimestampFromDateRange(value: DateRangeValue): number | undef
     "90d": 24 * 90,
   };
 
-  return now - hours[value.preset] * 60 * 60 * 1000;
+  // For presets, only return since (no until needed)
+  return { since: now - hours[value.preset] * 60 * 60 * 1000 };
+}
+
+// Legacy function for backwards compatibility
+export function getTimestampFromDateRange(value: DateRangeValue): number | undefined {
+  return getTimestampsFromDateRange(value).since;
 }
 
 // Legacy function for backwards compatibility

--- a/src/hooks/use-paginated-data.ts
+++ b/src/hooks/use-paginated-data.ts
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useAutoRefresh } from "@/hooks/use-auto-refresh";
 import { useNewItems } from "@/hooks/use-new-items";
 import { useApi } from "@/hooks/use-api";
-import { DateRangeValue, getTimestampFromDateRange } from "@/components/date-range-filter";
+import { DateRangeValue, getTimestampsFromDateRange } from "@/components/date-range-filter";
 
 export interface PaginatedResult<T> {
   items: T[];
@@ -17,13 +17,15 @@ export interface UsePaginatedDataConfig<TItem, TAggregates> {
     limit: number,
     offset: number,
     accountId: string | undefined,
-    since: number | undefined
+    since: number | undefined,
+    until: number | undefined
   ) => Promise<PaginatedResult<TItem>>;
 
   /** Fetch aggregates for the given account and date range */
   fetchAggregates: (
     accountId: string | undefined,
-    since: number | undefined
+    since: number | undefined,
+    until: number | undefined
   ) => Promise<TAggregates>;
 
   /** Fixed account ID for account-specific pages (undefined for global pages) */
@@ -115,12 +117,12 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   const doFetchAggregates = useCallback(
     async (accId: string, dateRangeValue: DateRangeValue) => {
       setIsLoadingAggregates(true);
-      const since = getTimestampFromDateRange(dateRangeValue);
+      const { since, until } = getTimestampsFromDateRange(dateRangeValue);
       const effectiveAccountId = accId === "all" ? undefined : accId;
 
       try {
         const data = await withErrorReporting(() =>
-          fetchAggregates(effectiveAccountId, since)
+          fetchAggregates(effectiveAccountId, since, until)
         );
         setAggregates(data);
       } catch (error) {
@@ -136,12 +138,12 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   const doFetchItems = useCallback(
     async (pageNum: number, accId: string, dateRangeValue: DateRangeValue) => {
       setIsLoading(true);
-      const since = getTimestampFromDateRange(dateRangeValue);
+      const { since, until } = getTimestampsFromDateRange(dateRangeValue);
       const effectiveAccountId = accId === "all" ? undefined : accId;
 
       try {
         const data = await withErrorReporting(() =>
-          fetchItems(pageSize, pageNum * pageSize, effectiveAccountId, since)
+          fetchItems(pageSize, pageNum * pageSize, effectiveAccountId, since, until)
         );
         setItems(data.items);
         setTotalCount(data.totalCount);

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -9,28 +9,40 @@ import {
   DELETE_ACCOUNT,
   GET_TRADES,
   GET_TRADES_WITH_FILTER,
+  GET_TRADES_WITH_RANGE_FILTER,
   GET_TRADES_BY_ACCOUNT,
   GET_TRADES_BY_ACCOUNT_WITH_FILTER,
+  GET_TRADES_BY_ACCOUNT_WITH_RANGE_FILTER,
   GET_TRADES_COUNT,
   GET_TRADES_COUNT_WITH_FILTER,
+  GET_TRADES_COUNT_WITH_RANGE_FILTER,
   GET_TRADES_COUNT_BY_ACCOUNT,
   GET_TRADES_COUNT_BY_ACCOUNT_WITH_FILTER,
+  GET_TRADES_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER,
   GET_TRADES_AGGREGATES,
   GET_TRADES_AGGREGATES_WITH_FILTER,
+  GET_TRADES_AGGREGATES_WITH_RANGE_FILTER,
   GET_TRADES_AGGREGATES_BY_ACCOUNT,
   GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_FILTER,
+  GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER,
   GET_FUNDING_PAYMENTS,
   GET_FUNDING_PAYMENTS_WITH_FILTER,
+  GET_FUNDING_PAYMENTS_WITH_RANGE_FILTER,
   GET_FUNDING_PAYMENTS_BY_ACCOUNT,
   GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_FILTER,
+  GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_RANGE_FILTER,
   GET_FUNDING_PAYMENTS_COUNT,
   GET_FUNDING_PAYMENTS_COUNT_WITH_FILTER,
+  GET_FUNDING_PAYMENTS_COUNT_WITH_RANGE_FILTER,
   GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT,
   GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_FILTER,
+  GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER,
   GET_FUNDING_AGGREGATES,
   GET_FUNDING_AGGREGATES_WITH_FILTER,
+  GET_FUNDING_AGGREGATES_WITH_RANGE_FILTER,
   GET_FUNDING_AGGREGATES_BY_ACCOUNT,
   GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_FILTER,
+  GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER,
   Exchange,
   ExchangeAccount,
   ExchangeAccountType,
@@ -135,13 +147,28 @@ export const graphqlApi: ApiClient = {
     });
   },
 
-  async getTrades(limit: number, offset: number, since?: number): Promise<TradesResult> {
+  async getTrades(limit: number, offset: number, since?: number, until?: number): Promise<TradesResult> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
 
       // Use different queries based on whether filter is provided
-      // Hasura doesn't handle null properly in _gte comparisons
-      if (since !== undefined) {
+      // Hasura doesn't handle null properly in _gte/_lte comparisons
+      if (since !== undefined && until !== undefined) {
+        // Range filter (custom date range)
+        const sinceBigint = String(since);
+        const untilBigint = String(until);
+        const [tradesData, countData] = await Promise.all([
+          client.request<{ trades: Trade[] }>(GET_TRADES_WITH_RANGE_FILTER, { limit, offset, since: sinceBigint, until: untilBigint }),
+          client.request<{
+            trades_aggregate: { aggregate: { count: number } };
+          }>(GET_TRADES_COUNT_WITH_RANGE_FILTER, { since: sinceBigint, until: untilBigint }),
+        ]);
+        return {
+          trades: tradesData.trades,
+          totalCount: countData.trades_aggregate.aggregate.count,
+        };
+      } else if (since !== undefined) {
+        // Since-only filter (presets like 24h, 7d, etc.)
         const sinceBigint = String(since);
         const [tradesData, countData] = await Promise.all([
           client.request<{ trades: Trade[] }>(GET_TRADES_WITH_FILTER, { limit, offset, since: sinceBigint }),
@@ -154,6 +181,7 @@ export const graphqlApi: ApiClient = {
           totalCount: countData.trades_aggregate.aggregate.count,
         };
       } else {
+        // No filter
         const [tradesData, countData] = await Promise.all([
           client.request<{ trades: Trade[] }>(GET_TRADES, { limit, offset }),
           client.request<{
@@ -172,13 +200,33 @@ export const graphqlApi: ApiClient = {
     accountId: string,
     limit: number,
     offset: number,
-    since?: number
+    since?: number,
+    until?: number
   ): Promise<TradesResult> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
 
       // Use different queries based on whether filter is provided
-      if (since !== undefined) {
+      if (since !== undefined && until !== undefined) {
+        const sinceBigint = String(since);
+        const untilBigint = String(until);
+        const [tradesData, countData] = await Promise.all([
+          client.request<{ trades: Trade[] }>(GET_TRADES_BY_ACCOUNT_WITH_RANGE_FILTER, {
+            accountId,
+            limit,
+            offset,
+            since: sinceBigint,
+            until: untilBigint,
+          }),
+          client.request<{
+            trades_aggregate: { aggregate: { count: number } };
+          }>(GET_TRADES_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER, { accountId, since: sinceBigint, until: untilBigint }),
+        ]);
+        return {
+          trades: tradesData.trades,
+          totalCount: countData.trades_aggregate.aggregate.count,
+        };
+      } else if (since !== undefined) {
         const sinceBigint = String(since);
         const [tradesData, countData] = await Promise.all([
           client.request<{ trades: Trade[] }>(GET_TRADES_BY_ACCOUNT_WITH_FILTER, {
@@ -214,13 +262,23 @@ export const graphqlApi: ApiClient = {
     });
   },
 
-  async getTradesAggregates(since?: number): Promise<TradesAggregates> {
+  async getTradesAggregates(since?: number, until?: number): Promise<TradesAggregates> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
 
       // Use different queries based on whether filter is provided
-      const query = since !== undefined ? GET_TRADES_AGGREGATES_WITH_FILTER : GET_TRADES_AGGREGATES;
-      const variables = since !== undefined ? { since: String(since) } : {};
+      let query;
+      let variables: Record<string, string> = {};
+
+      if (since !== undefined && until !== undefined) {
+        query = GET_TRADES_AGGREGATES_WITH_RANGE_FILTER;
+        variables = { since: String(since), until: String(until) };
+      } else if (since !== undefined) {
+        query = GET_TRADES_AGGREGATES_WITH_FILTER;
+        variables = { since: String(since) };
+      } else {
+        query = GET_TRADES_AGGREGATES;
+      }
 
       const data = await client.request<{
         trades_aggregate: {
@@ -239,13 +297,23 @@ export const graphqlApi: ApiClient = {
     });
   },
 
-  async getTradesAggregatesByAccount(accountId: string, since?: number): Promise<TradesAggregates> {
+  async getTradesAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<TradesAggregates> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
 
       // Use different queries based on whether filter is provided
-      const query = since !== undefined ? GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_FILTER : GET_TRADES_AGGREGATES_BY_ACCOUNT;
-      const variables = since !== undefined ? { accountId, since: String(since) } : { accountId };
+      let query;
+      let variables: Record<string, string> = { accountId };
+
+      if (since !== undefined && until !== undefined) {
+        query = GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER;
+        variables = { accountId, since: String(since), until: String(until) };
+      } else if (since !== undefined) {
+        query = GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_FILTER;
+        variables = { accountId, since: String(since) };
+      } else {
+        query = GET_TRADES_AGGREGATES_BY_ACCOUNT;
+      }
 
       const data = await client.request<{
         trades_aggregate: {
@@ -264,13 +332,26 @@ export const graphqlApi: ApiClient = {
     });
   },
 
-  async getFundingPayments(limit: number, offset: number, since?: number): Promise<FundingPaymentsResult> {
+  async getFundingPayments(limit: number, offset: number, since?: number, until?: number): Promise<FundingPaymentsResult> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
 
       // Use different queries based on whether filter is provided
-      // Hasura doesn't accept null for bigint _gte comparisons
-      if (since !== undefined) {
+      // Hasura doesn't accept null for bigint _gte/_lte comparisons
+      if (since !== undefined && until !== undefined) {
+        const sinceBigint = String(since);
+        const untilBigint = String(until);
+        const [fundingData, countData] = await Promise.all([
+          client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_WITH_RANGE_FILTER, { limit, offset, since: sinceBigint, until: untilBigint }),
+          client.request<{
+            funding_payments_aggregate: { aggregate: { count: number } };
+          }>(GET_FUNDING_PAYMENTS_COUNT_WITH_RANGE_FILTER, { since: sinceBigint, until: untilBigint }),
+        ]);
+        return {
+          fundingPayments: fundingData.funding_payments,
+          totalCount: countData.funding_payments_aggregate.aggregate.count,
+        };
+      } else if (since !== undefined) {
         const sinceBigint = String(since);
         const [fundingData, countData] = await Promise.all([
           client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_WITH_FILTER, { limit, offset, since: sinceBigint }),
@@ -301,13 +382,33 @@ export const graphqlApi: ApiClient = {
     accountId: string,
     limit: number,
     offset: number,
-    since?: number
+    since?: number,
+    until?: number
   ): Promise<FundingPaymentsResult> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
 
       // Use different queries based on whether filter is provided
-      if (since !== undefined) {
+      if (since !== undefined && until !== undefined) {
+        const sinceBigint = String(since);
+        const untilBigint = String(until);
+        const [fundingData, countData] = await Promise.all([
+          client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_RANGE_FILTER, {
+            accountId,
+            limit,
+            offset,
+            since: sinceBigint,
+            until: untilBigint,
+          }),
+          client.request<{
+            funding_payments_aggregate: { aggregate: { count: number } };
+          }>(GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER, { accountId, since: sinceBigint, until: untilBigint }),
+        ]);
+        return {
+          fundingPayments: fundingData.funding_payments,
+          totalCount: countData.funding_payments_aggregate.aggregate.count,
+        };
+      } else if (since !== undefined) {
         const sinceBigint = String(since);
         const [fundingData, countData] = await Promise.all([
           client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_FILTER, {
@@ -343,13 +444,23 @@ export const graphqlApi: ApiClient = {
     });
   },
 
-  async getFundingAggregates(since?: number): Promise<FundingAggregates> {
+  async getFundingAggregates(since?: number, until?: number): Promise<FundingAggregates> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
 
       // Use different queries based on whether filter is provided
-      const query = since !== undefined ? GET_FUNDING_AGGREGATES_WITH_FILTER : GET_FUNDING_AGGREGATES;
-      const variables = since !== undefined ? { since: String(since) } : {};
+      let query;
+      let variables: Record<string, string> = {};
+
+      if (since !== undefined && until !== undefined) {
+        query = GET_FUNDING_AGGREGATES_WITH_RANGE_FILTER;
+        variables = { since: String(since), until: String(until) };
+      } else if (since !== undefined) {
+        query = GET_FUNDING_AGGREGATES_WITH_FILTER;
+        variables = { since: String(since) };
+      } else {
+        query = GET_FUNDING_AGGREGATES;
+      }
 
       const data = await client.request<{
         funding_payments_aggregate: {
@@ -367,13 +478,23 @@ export const graphqlApi: ApiClient = {
     });
   },
 
-  async getFundingAggregatesByAccount(accountId: string, since?: number): Promise<FundingAggregates> {
+  async getFundingAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<FundingAggregates> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
 
       // Use different queries based on whether filter is provided
-      const query = since !== undefined ? GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_FILTER : GET_FUNDING_AGGREGATES_BY_ACCOUNT;
-      const variables = since !== undefined ? { accountId, since: String(since) } : { accountId };
+      let query;
+      let variables: Record<string, string> = { accountId };
+
+      if (since !== undefined && until !== undefined) {
+        query = GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER;
+        variables = { accountId, since: String(since), until: String(until) };
+      } else if (since !== undefined) {
+        query = GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_FILTER;
+        variables = { accountId, since: String(since) };
+      } else {
+        query = GET_FUNDING_AGGREGATES_BY_ACCOUNT;
+      }
 
       const data = await client.request<{
         funding_payments_aggregate: {

--- a/src/lib/api/mock.ts
+++ b/src/lib/api/mock.ts
@@ -246,12 +246,16 @@ export const mockApi: ApiClient = {
     return { id };
   },
 
-  async getTrades(limit: number, offset: number, since?: number): Promise<TradesResult> {
+  async getTrades(limit: number, offset: number, since?: number, until?: number): Promise<TradesResult> {
     await delay(300);
-    // Filter by timestamp if since is provided
-    const filteredTrades = since
-      ? mockTrades.filter((trade) => new Date(trade.timestamp).getTime() >= since)
-      : mockTrades;
+    // Filter by timestamp if since/until is provided
+    let filteredTrades = mockTrades;
+    if (since) {
+      filteredTrades = filteredTrades.filter((trade) => new Date(trade.timestamp).getTime() >= since);
+    }
+    if (until) {
+      filteredTrades = filteredTrades.filter((trade) => new Date(trade.timestamp).getTime() <= until);
+    }
     const paginatedTrades = filteredTrades.slice(offset, offset + limit);
     return {
       trades: paginatedTrades,
@@ -263,16 +267,22 @@ export const mockApi: ApiClient = {
     accountId: string,
     limit: number,
     offset: number,
-    since?: number
+    since?: number,
+    until?: number
   ): Promise<TradesResult> {
     await delay(300);
     let accountTrades = mockTrades.filter(
       (trade) => trade.exchange_account_id === accountId
     );
-    // Filter by timestamp if since is provided
+    // Filter by timestamp if since/until is provided
     if (since) {
       accountTrades = accountTrades.filter(
         (trade) => new Date(trade.timestamp).getTime() >= since
+      );
+    }
+    if (until) {
+      accountTrades = accountTrades.filter(
+        (trade) => new Date(trade.timestamp).getTime() <= until
       );
     }
     const paginatedTrades = accountTrades.slice(offset, offset + limit);
@@ -282,12 +292,16 @@ export const mockApi: ApiClient = {
     };
   },
 
-  async getTradesAggregates(since?: number): Promise<TradesAggregates> {
+  async getTradesAggregates(since?: number, until?: number): Promise<TradesAggregates> {
     await delay(200);
-    // Filter by timestamp if since is provided
-    const filteredTrades = since
-      ? mockTrades.filter((trade) => new Date(trade.timestamp).getTime() >= since)
-      : mockTrades;
+    // Filter by timestamp if since/until is provided
+    let filteredTrades = mockTrades;
+    if (since) {
+      filteredTrades = filteredTrades.filter((trade) => new Date(trade.timestamp).getTime() >= since);
+    }
+    if (until) {
+      filteredTrades = filteredTrades.filter((trade) => new Date(trade.timestamp).getTime() <= until);
+    }
     const totalFees = filteredTrades.reduce(
       (sum, trade) => sum + parseFloat(trade.fee),
       0
@@ -299,15 +313,20 @@ export const mockApi: ApiClient = {
     };
   },
 
-  async getTradesAggregatesByAccount(accountId: string, since?: number): Promise<TradesAggregates> {
+  async getTradesAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<TradesAggregates> {
     await delay(200);
     let accountTrades = mockTrades.filter(
       (trade) => trade.exchange_account_id === accountId
     );
-    // Filter by timestamp if since is provided
+    // Filter by timestamp if since/until is provided
     if (since) {
       accountTrades = accountTrades.filter(
         (trade) => new Date(trade.timestamp).getTime() >= since
+      );
+    }
+    if (until) {
+      accountTrades = accountTrades.filter(
+        (trade) => new Date(trade.timestamp).getTime() <= until
       );
     }
     const totalFees = accountTrades.reduce(
@@ -321,12 +340,16 @@ export const mockApi: ApiClient = {
     };
   },
 
-  async getFundingPayments(limit: number, offset: number, since?: number): Promise<FundingPaymentsResult> {
+  async getFundingPayments(limit: number, offset: number, since?: number, until?: number): Promise<FundingPaymentsResult> {
     await delay(300);
-    // Filter by timestamp if since is provided (funding payments use unix ms)
-    const filteredPayments = since
-      ? mockFundingPayments.filter((payment) => payment.timestamp >= since)
-      : mockFundingPayments;
+    // Filter by timestamp if since/until is provided (funding payments use unix ms)
+    let filteredPayments = mockFundingPayments;
+    if (since) {
+      filteredPayments = filteredPayments.filter((payment) => payment.timestamp >= since);
+    }
+    if (until) {
+      filteredPayments = filteredPayments.filter((payment) => payment.timestamp <= until);
+    }
     const paginatedPayments = filteredPayments.slice(offset, offset + limit);
     return {
       fundingPayments: paginatedPayments,
@@ -338,16 +361,22 @@ export const mockApi: ApiClient = {
     accountId: string,
     limit: number,
     offset: number,
-    since?: number
+    since?: number,
+    until?: number
   ): Promise<FundingPaymentsResult> {
     await delay(300);
     let accountPayments = mockFundingPayments.filter(
       (payment) => payment.exchange_account_id === accountId
     );
-    // Filter by timestamp if since is provided
+    // Filter by timestamp if since/until is provided
     if (since) {
       accountPayments = accountPayments.filter(
         (payment) => payment.timestamp >= since
+      );
+    }
+    if (until) {
+      accountPayments = accountPayments.filter(
+        (payment) => payment.timestamp <= until
       );
     }
     const paginatedPayments = accountPayments.slice(offset, offset + limit);
@@ -357,12 +386,16 @@ export const mockApi: ApiClient = {
     };
   },
 
-  async getFundingAggregates(since?: number): Promise<FundingAggregates> {
+  async getFundingAggregates(since?: number, until?: number): Promise<FundingAggregates> {
     await delay(200);
-    // Filter by timestamp if since is provided
-    const filteredPayments = since
-      ? mockFundingPayments.filter((payment) => payment.timestamp >= since)
-      : mockFundingPayments;
+    // Filter by timestamp if since/until is provided
+    let filteredPayments = mockFundingPayments;
+    if (since) {
+      filteredPayments = filteredPayments.filter((payment) => payment.timestamp >= since);
+    }
+    if (until) {
+      filteredPayments = filteredPayments.filter((payment) => payment.timestamp <= until);
+    }
     const totalAmount = filteredPayments.reduce(
       (sum, payment) => sum + parseFloat(payment.amount),
       0
@@ -373,15 +406,20 @@ export const mockApi: ApiClient = {
     };
   },
 
-  async getFundingAggregatesByAccount(accountId: string, since?: number): Promise<FundingAggregates> {
+  async getFundingAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<FundingAggregates> {
     await delay(200);
     let accountPayments = mockFundingPayments.filter(
       (payment) => payment.exchange_account_id === accountId
     );
-    // Filter by timestamp if since is provided
+    // Filter by timestamp if since/until is provided
     if (since) {
       accountPayments = accountPayments.filter(
         (payment) => payment.timestamp >= since
+      );
+    }
+    if (until) {
+      accountPayments = accountPayments.filter(
+        (payment) => payment.timestamp <= until
       );
     }
     const totalAmount = accountPayments.reduce(

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -24,22 +24,24 @@ export interface ApiClient {
   getAccountById(id: string): Promise<ExchangeAccount | null>;
   createAccount(input: CreateAccountInput): Promise<ExchangeAccount>;
   deleteAccount(id: string): Promise<{ id: string }>;
-  getTrades(limit: number, offset: number, since?: number): Promise<TradesResult>;
+  getTrades(limit: number, offset: number, since?: number, until?: number): Promise<TradesResult>;
   getTradesByAccount(
     accountId: string,
     limit: number,
     offset: number,
-    since?: number
+    since?: number,
+    until?: number
   ): Promise<TradesResult>;
-  getTradesAggregates(since?: number): Promise<TradesAggregates>;
-  getTradesAggregatesByAccount(accountId: string, since?: number): Promise<TradesAggregates>;
-  getFundingPayments(limit: number, offset: number, since?: number): Promise<FundingPaymentsResult>;
+  getTradesAggregates(since?: number, until?: number): Promise<TradesAggregates>;
+  getTradesAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<TradesAggregates>;
+  getFundingPayments(limit: number, offset: number, since?: number, until?: number): Promise<FundingPaymentsResult>;
   getFundingPaymentsByAccount(
     accountId: string,
     limit: number,
     offset: number,
-    since?: number
+    since?: number,
+    until?: number
   ): Promise<FundingPaymentsResult>;
-  getFundingAggregates(since?: number): Promise<FundingAggregates>;
-  getFundingAggregatesByAccount(accountId: string, since?: number): Promise<FundingAggregates>;
+  getFundingAggregates(since?: number, until?: number): Promise<FundingAggregates>;
+  getFundingAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<FundingAggregates>;
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -176,6 +176,39 @@ export const GET_TRADES_WITH_FILTER = gql`
   }
 `;
 
+export const GET_TRADES_WITH_RANGE_FILTER = gql`
+  query GetTradesWithRangeFilter($limit: Int!, $offset: Int!, $since: bigint!, $until: bigint!) {
+    trades(
+      limit: $limit
+      offset: $offset
+      order_by: { timestamp: desc }
+      where: { timestamp: { _gte: $since, _lte: $until } }
+    ) {
+      id
+      base_asset
+      quote_asset
+      side
+      price
+      quantity
+      timestamp
+      fee
+      order_id
+      trade_id
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+  }
+`;
+
 export const GET_TRADES_BY_ACCOUNT = gql`
   query GetTradesByAccount($accountId: uuid!, $limit: Int!, $offset: Int!) {
     trades(
@@ -242,6 +275,39 @@ export const GET_TRADES_BY_ACCOUNT_WITH_FILTER = gql`
   }
 `;
 
+export const GET_TRADES_BY_ACCOUNT_WITH_RANGE_FILTER = gql`
+  query GetTradesByAccountWithRangeFilter($accountId: uuid!, $limit: Int!, $offset: Int!, $since: bigint!, $until: bigint!) {
+    trades(
+      where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since, _lte: $until } }
+      limit: $limit
+      offset: $offset
+      order_by: { timestamp: desc }
+    ) {
+      id
+      base_asset
+      quote_asset
+      side
+      price
+      quantity
+      timestamp
+      fee
+      order_id
+      trade_id
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+  }
+`;
+
 export const GET_TRADES_COUNT = gql`
   query GetTradesCount {
     trades_aggregate {
@@ -262,6 +328,16 @@ export const GET_TRADES_COUNT_WITH_FILTER = gql`
   }
 `;
 
+export const GET_TRADES_COUNT_WITH_RANGE_FILTER = gql`
+  query GetTradesCountWithRangeFilter($since: bigint!, $until: bigint!) {
+    trades_aggregate(where: { timestamp: { _gte: $since, _lte: $until } }) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
 export const GET_TRADES_COUNT_BY_ACCOUNT = gql`
   query GetTradesCountByAccount($accountId: uuid!) {
     trades_aggregate(where: { exchange_account_id: { _eq: $accountId } }) {
@@ -275,6 +351,16 @@ export const GET_TRADES_COUNT_BY_ACCOUNT = gql`
 export const GET_TRADES_COUNT_BY_ACCOUNT_WITH_FILTER = gql`
   query GetTradesCountByAccountWithFilter($accountId: uuid!, $since: bigint!) {
     trades_aggregate(where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since } }) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export const GET_TRADES_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER = gql`
+  query GetTradesCountByAccountWithRangeFilter($accountId: uuid!, $since: bigint!, $until: bigint!) {
+    trades_aggregate(where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since, _lte: $until } }) {
       aggregate {
         count
       }
@@ -316,6 +402,19 @@ export const GET_TRADES_AGGREGATES_WITH_FILTER = gql`
   }
 `;
 
+export const GET_TRADES_AGGREGATES_WITH_RANGE_FILTER = gql`
+  query GetTradesAggregatesWithRangeFilter($since: bigint!, $until: bigint!) {
+    trades_aggregate(where: { timestamp: { _gte: $since, _lte: $until } }) {
+      aggregate {
+        count
+        sum {
+          fee
+        }
+      }
+    }
+  }
+`;
+
 export const GET_TRADES_AGGREGATES_BY_ACCOUNT = gql`
   query GetTradesAggregatesByAccount($accountId: uuid!) {
     trades_aggregate(where: { exchange_account_id: { _eq: $accountId } }) {
@@ -332,6 +431,19 @@ export const GET_TRADES_AGGREGATES_BY_ACCOUNT = gql`
 export const GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_FILTER = gql`
   query GetTradesAggregatesByAccountWithFilter($accountId: uuid!, $since: bigint!) {
     trades_aggregate(where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since } }) {
+      aggregate {
+        count
+        sum {
+          fee
+        }
+      }
+    }
+  }
+`;
+
+export const GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER = gql`
+  query GetTradesAggregatesByAccountWithRangeFilter($accountId: uuid!, $since: bigint!, $until: bigint!) {
+    trades_aggregate(where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since, _lte: $until } }) {
       aggregate {
         count
         sum {
@@ -414,6 +526,35 @@ export const GET_FUNDING_PAYMENTS_WITH_FILTER = gql`
   }
 `;
 
+export const GET_FUNDING_PAYMENTS_WITH_RANGE_FILTER = gql`
+  query GetFundingPaymentsWithRangeFilter($limit: Int!, $offset: Int!, $since: bigint!, $until: bigint!) {
+    funding_payments(
+      limit: $limit
+      offset: $offset
+      order_by: { timestamp: desc }
+      where: { timestamp: { _gte: $since, _lte: $until } }
+    ) {
+      id
+      base_asset
+      quote_asset
+      amount
+      timestamp
+      payment_id
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+  }
+`;
+
 export const GET_FUNDING_PAYMENTS_BY_ACCOUNT = gql`
   query GetFundingPaymentsByAccount($accountId: uuid!, $limit: Int!, $offset: Int!) {
     funding_payments(
@@ -472,6 +613,35 @@ export const GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_FILTER = gql`
   }
 `;
 
+export const GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_RANGE_FILTER = gql`
+  query GetFundingPaymentsByAccountWithRangeFilter($accountId: uuid!, $limit: Int!, $offset: Int!, $since: bigint!, $until: bigint!) {
+    funding_payments(
+      where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since, _lte: $until } }
+      limit: $limit
+      offset: $offset
+      order_by: { timestamp: desc }
+    ) {
+      id
+      base_asset
+      quote_asset
+      amount
+      timestamp
+      payment_id
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+  }
+`;
+
 export const GET_FUNDING_PAYMENTS_COUNT = gql`
   query GetFundingPaymentsCount {
     funding_payments_aggregate {
@@ -492,6 +662,16 @@ export const GET_FUNDING_PAYMENTS_COUNT_WITH_FILTER = gql`
   }
 `;
 
+export const GET_FUNDING_PAYMENTS_COUNT_WITH_RANGE_FILTER = gql`
+  query GetFundingPaymentsCountWithRangeFilter($since: bigint!, $until: bigint!) {
+    funding_payments_aggregate(where: { timestamp: { _gte: $since, _lte: $until } }) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
 export const GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT = gql`
   query GetFundingPaymentsCountByAccount($accountId: uuid!) {
     funding_payments_aggregate(where: { exchange_account_id: { _eq: $accountId } }) {
@@ -505,6 +685,16 @@ export const GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT = gql`
 export const GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_FILTER = gql`
   query GetFundingPaymentsCountByAccountWithFilter($accountId: uuid!, $since: bigint!) {
     funding_payments_aggregate(where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since } }) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export const GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER = gql`
+  query GetFundingPaymentsCountByAccountWithRangeFilter($accountId: uuid!, $since: bigint!, $until: bigint!) {
+    funding_payments_aggregate(where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since, _lte: $until } }) {
       aggregate {
         count
       }
@@ -545,6 +735,19 @@ export const GET_FUNDING_AGGREGATES_WITH_FILTER = gql`
   }
 `;
 
+export const GET_FUNDING_AGGREGATES_WITH_RANGE_FILTER = gql`
+  query GetFundingAggregatesWithRangeFilter($since: bigint!, $until: bigint!) {
+    funding_payments_aggregate(where: { timestamp: { _gte: $since, _lte: $until } }) {
+      aggregate {
+        count
+        sum {
+          amount
+        }
+      }
+    }
+  }
+`;
+
 export const GET_FUNDING_AGGREGATES_BY_ACCOUNT = gql`
   query GetFundingAggregatesByAccount($accountId: uuid!) {
     funding_payments_aggregate(where: { exchange_account_id: { _eq: $accountId } }) {
@@ -561,6 +764,19 @@ export const GET_FUNDING_AGGREGATES_BY_ACCOUNT = gql`
 export const GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_FILTER = gql`
   query GetFundingAggregatesByAccountWithFilter($accountId: uuid!, $since: bigint!) {
     funding_payments_aggregate(where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since } }) {
+      aggregate {
+        count
+        sum {
+          amount
+        }
+      }
+    }
+  }
+`;
+
+export const GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER = gql`
+  query GetFundingAggregatesByAccountWithRangeFilter($accountId: uuid!, $since: bigint!, $until: bigint!) {
+    funding_payments_aggregate(where: { exchange_account_id: { _eq: $accountId }, timestamp: { _gte: $since, _lte: $until } }) {
       aggregate {
         count
         sum {


### PR DESCRIPTION
Previously, when selecting a custom date range (e.g., Jan 1-31, 2025), only the "from" date was being used in the filter, which caused all trades/funding payments after that date to be shown regardless of the "to" date.

This fix:
- Updates getTimestampsFromDateRange to return both since and until
- Adds _WITH_RANGE_FILTER variants for all GraphQL queries with both _gte and _lte filters
- Updates all API methods to accept and pass the until parameter
- Updates usePaginatedData hook to extract and pass both timestamps
- Updates all page components to pass both since and until to fetch functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)