### PR TITLE
Remove legacy backwards-compatible functions

### DIFF
--- a/src/components/date-range-filter.tsx
+++ b/src/components/date-range-filter.tsx
@@ -66,16 +66,6 @@ export function getTimestampsFromDateRange(value: DateRangeValue): DateRangeTime
   return { since: now - hours[value.preset] * 60 * 60 * 1000 };
 }
 
-// Legacy function for backwards compatibility
-export function getTimestampFromDateRange(value: DateRangeValue): number | undefined {
-  return getTimestampsFromDateRange(value).since;
-}
-
-// Legacy function for backwards compatibility
-export function getTimestampFromPreset(preset: DateRangePreset): number | undefined {
-  return getTimestampFromDateRange({ preset });
-}
-
 export function DateRangeFilter({
   value,
   onChange,


### PR DESCRIPTION
Remove unused getTimestampFromDateRange and getTimestampFromPreset functions that were kept for backwards compatibility. The codebase now exclusively uses getTimestampsFromDateRange which returns both since and until values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)