### PR TITLE
Add multi-select asset filter to trades and funding pages

### DIFF
--- a/src/app/(dashboard)/accounts/[id]/funding/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/funding/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, use } from "react";
 import Link from "next/link";
-import { api } from "@/lib/api";
+import { api, DataFilters } from "@/lib/api";
 import { FundingPayment, ExchangeAccount, FundingAggregates } from "@/lib/queries";
 import { FundingTable } from "@/components/funding-table";
 import { SyncButton } from "@/components/sync-button";
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { StatCard, StatsGrid } from "@/components/stat-card";
 import { formatSignedNumber } from "@/lib/format";
 import { DateRangeFilter } from "@/components/date-range-filter";
+import { AssetFilter } from "@/components/asset-filter";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
@@ -18,25 +19,14 @@ const PAGE_SIZE = 100;
 async function fetchFundingPayments(
   limit: number,
   offset: number,
-  accountId: string | undefined,
-  since: number | undefined,
-  until: number | undefined
+  filters: DataFilters
 ) {
-  const data = accountId
-    ? await api.getFundingPaymentsByAccount(accountId, limit, offset, since, until)
-    : await api.getFundingPayments(limit, offset, since, until);
-
+  const data = await api.getFundingPayments(limit, offset, filters);
   return { items: data.fundingPayments, totalCount: data.totalCount };
 }
 
-async function fetchFundingAggregates(
-  accountId: string | undefined,
-  since: number | undefined,
-  until: number | undefined
-) {
-  return accountId
-    ? api.getFundingAggregatesByAccount(accountId, since, until)
-    : api.getFundingAggregates(since, until);
+async function fetchFundingAggregates(filters: DataFilters) {
+  return api.getFundingAggregates(filters);
 }
 
 interface AccountFundingPageProps {
@@ -46,6 +36,8 @@ interface AccountFundingPageProps {
 export default function AccountFundingPage({ params }: AccountFundingPageProps) {
   const { id } = use(params);
   const [account, setAccount] = useState<ExchangeAccount | null>(null);
+  const [availableAssets, setAvailableAssets] = useState<string[]>([]);
+  const [isLoadingAssets, setIsLoadingAssets] = useState(true);
 
   const {
     items: fundingPayments,
@@ -55,9 +47,11 @@ export default function AccountFundingPage({ params }: AccountFundingPageProps) 
     isLoadingAggregates,
     page,
     dateRange,
+    selectedAssets,
     isNew,
     handlePageChange,
     handleDateRangeChange,
+    handleAssetChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<FundingPayment, FundingAggregates>({
@@ -78,6 +72,21 @@ export default function AccountFundingPage({ params }: AccountFundingPageProps) 
     };
     fetchAccount();
   }, [id]);
+
+  useEffect(() => {
+    const fetchAssets = async () => {
+      setIsLoadingAssets(true);
+      try {
+        const assets = await api.getDistinctBaseAssets("funding");
+        setAvailableAssets(assets);
+      } catch (error) {
+        console.error("Failed to fetch assets:", error);
+      } finally {
+        setIsLoadingAssets(false);
+      }
+    };
+    fetchAssets();
+  }, []);
 
   const accountTitle = account
     ? `${account.exchange?.display_name || "Unknown"} - ${account.account_identifier.slice(0, 10)}...`
@@ -120,7 +129,15 @@ export default function AccountFundingPage({ params }: AccountFundingPageProps) 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <CardTitle>Funding Payments</CardTitle>
-          <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
+          <div className="flex items-center gap-4">
+            <AssetFilter
+              assets={availableAssets}
+              selectedAssets={selectedAssets}
+              onSelectionChange={handleAssetChange}
+              isLoading={isLoadingAssets}
+            />
+            <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
+          </div>
         </CardHeader>
         <CardContent>
           <FundingTable

--- a/src/app/(dashboard)/accounts/[id]/trades/page.tsx
+++ b/src/app/(dashboard)/accounts/[id]/trades/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, use } from "react";
 import Link from "next/link";
-import { api } from "@/lib/api";
+import { api, DataFilters } from "@/lib/api";
 import { Trade, ExchangeAccount, TradesAggregates } from "@/lib/queries";
 import { TradesTable } from "@/components/trades-table";
 import { SyncButton } from "@/components/sync-button";
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { StatCard, StatsGrid } from "@/components/stat-card";
 import { DateRangeFilter } from "@/components/date-range-filter";
+import { AssetFilter } from "@/components/asset-filter";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
@@ -17,25 +18,14 @@ const PAGE_SIZE = 100;
 async function fetchTrades(
   limit: number,
   offset: number,
-  accountId: string | undefined,
-  since: number | undefined,
-  until: number | undefined
+  filters: DataFilters
 ) {
-  const data = accountId
-    ? await api.getTradesByAccount(accountId, limit, offset, since, until)
-    : await api.getTrades(limit, offset, since, until);
-
+  const data = await api.getTrades(limit, offset, filters);
   return { items: data.trades, totalCount: data.totalCount };
 }
 
-async function fetchTradesAggregates(
-  accountId: string | undefined,
-  since: number | undefined,
-  until: number | undefined
-) {
-  return accountId
-    ? api.getTradesAggregatesByAccount(accountId, since, until)
-    : api.getTradesAggregates(since, until);
+async function fetchTradesAggregates(filters: DataFilters) {
+  return api.getTradesAggregates(filters);
 }
 
 interface AccountTradesPageProps {
@@ -45,6 +35,8 @@ interface AccountTradesPageProps {
 export default function AccountTradesPage({ params }: AccountTradesPageProps) {
   const { id } = use(params);
   const [account, setAccount] = useState<ExchangeAccount | null>(null);
+  const [availableAssets, setAvailableAssets] = useState<string[]>([]);
+  const [isLoadingAssets, setIsLoadingAssets] = useState(true);
 
   const {
     items: trades,
@@ -54,9 +46,11 @@ export default function AccountTradesPage({ params }: AccountTradesPageProps) {
     isLoadingAggregates,
     page,
     dateRange,
+    selectedAssets,
     isNew,
     handlePageChange,
     handleDateRangeChange,
+    handleAssetChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<Trade, TradesAggregates>({
@@ -77,6 +71,21 @@ export default function AccountTradesPage({ params }: AccountTradesPageProps) {
     };
     fetchAccount();
   }, [id]);
+
+  useEffect(() => {
+    const fetchAssets = async () => {
+      setIsLoadingAssets(true);
+      try {
+        const assets = await api.getDistinctBaseAssets("trades");
+        setAvailableAssets(assets);
+      } catch (error) {
+        console.error("Failed to fetch assets:", error);
+      } finally {
+        setIsLoadingAssets(false);
+      }
+    };
+    fetchAssets();
+  }, []);
 
   const formatFees = (value: string) => {
     const num = parseFloat(value);
@@ -121,7 +130,15 @@ export default function AccountTradesPage({ params }: AccountTradesPageProps) {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <CardTitle>Trades</CardTitle>
-          <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
+          <div className="flex items-center gap-4">
+            <AssetFilter
+              assets={availableAssets}
+              selectedAssets={selectedAssets}
+              onSelectionChange={handleAssetChange}
+              isLoading={isLoadingAssets}
+            />
+            <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
+          </div>
         </CardHeader>
         <CardContent>
           <TradesTable

--- a/src/app/(dashboard)/funding/page.tsx
+++ b/src/app/(dashboard)/funding/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { api } from "@/lib/api";
+import { api, DataFilters } from "@/lib/api";
 import { FundingPayment, ExchangeAccount, FundingAggregates } from "@/lib/queries";
 import { FundingTable } from "@/components/funding-table";
 import { AccountFilter } from "@/components/account-filter";
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatCard, StatsGrid } from "@/components/stat-card";
 import { formatSignedNumber } from "@/lib/format";
 import { DateRangeFilter } from "@/components/date-range-filter";
+import { AssetFilter } from "@/components/asset-filter";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
@@ -17,29 +18,20 @@ const PAGE_SIZE = 100;
 async function fetchFundingPayments(
   limit: number,
   offset: number,
-  accountId: string | undefined,
-  since: number | undefined,
-  until: number | undefined
+  filters: DataFilters
 ) {
-  const data = accountId
-    ? await api.getFundingPaymentsByAccount(accountId, limit, offset, since, until)
-    : await api.getFundingPayments(limit, offset, since, until);
-
+  const data = await api.getFundingPayments(limit, offset, filters);
   return { items: data.fundingPayments, totalCount: data.totalCount };
 }
 
-async function fetchFundingAggregates(
-  accountId: string | undefined,
-  since: number | undefined,
-  until: number | undefined
-) {
-  return accountId
-    ? api.getFundingAggregatesByAccount(accountId, since, until)
-    : api.getFundingAggregates(since, until);
+async function fetchFundingAggregates(filters: DataFilters) {
+  return api.getFundingAggregates(filters);
 }
 
 export default function FundingPage() {
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
+  const [availableAssets, setAvailableAssets] = useState<string[]>([]);
+  const [isLoadingAssets, setIsLoadingAssets] = useState(true);
 
   const {
     items: fundingPayments,
@@ -50,10 +42,12 @@ export default function FundingPage() {
     page,
     selectedAccountId,
     dateRange,
+    selectedAssets,
     isNew,
     handlePageChange,
     handleAccountChange,
     handleDateRangeChange,
+    handleAssetChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<FundingPayment, FundingAggregates>({
@@ -72,6 +66,21 @@ export default function FundingPage() {
       }
     };
     fetchAccounts();
+  }, []);
+
+  useEffect(() => {
+    const fetchAssets = async () => {
+      setIsLoadingAssets(true);
+      try {
+        const assets = await api.getDistinctBaseAssets("funding");
+        setAvailableAssets(assets);
+      } catch (error) {
+        console.error("Failed to fetch assets:", error);
+      } finally {
+        setIsLoadingAssets(false);
+      }
+    };
+    fetchAssets();
   }, []);
 
   const totalAmount = aggregates ? parseFloat(aggregates.totalAmount) : 0;
@@ -113,6 +122,12 @@ export default function FundingPage() {
             {selectedAccountId === "all" ? "All Funding Payments" : "Filtered Payments"}
           </CardTitle>
           <div className="flex items-center gap-4">
+            <AssetFilter
+              assets={availableAssets}
+              selectedAssets={selectedAssets}
+              onSelectionChange={handleAssetChange}
+              isLoading={isLoadingAssets}
+            />
             <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
             <AccountFilter
               accounts={accounts}

--- a/src/app/(dashboard)/trades/page.tsx
+++ b/src/app/(dashboard)/trades/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { api } from "@/lib/api";
+import { api, DataFilters } from "@/lib/api";
 import { Trade, ExchangeAccount, TradesAggregates } from "@/lib/queries";
 import { TradesTable } from "@/components/trades-table";
 import { SyncButton } from "@/components/sync-button";
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DateRangeFilter } from "@/components/date-range-filter";
+import { AssetFilter } from "@/components/asset-filter";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
@@ -22,29 +23,20 @@ const PAGE_SIZE = 100;
 async function fetchTrades(
   limit: number,
   offset: number,
-  accountId: string | undefined,
-  since: number | undefined,
-  until: number | undefined
+  filters: DataFilters
 ) {
-  const data = accountId
-    ? await api.getTradesByAccount(accountId, limit, offset, since, until)
-    : await api.getTrades(limit, offset, since, until);
-
+  const data = await api.getTrades(limit, offset, filters);
   return { items: data.trades, totalCount: data.totalCount };
 }
 
-async function fetchTradesAggregates(
-  accountId: string | undefined,
-  since: number | undefined,
-  until: number | undefined
-) {
-  return accountId
-    ? api.getTradesAggregatesByAccount(accountId, since, until)
-    : api.getTradesAggregates(since, until);
+async function fetchTradesAggregates(filters: DataFilters) {
+  return api.getTradesAggregates(filters);
 }
 
 export default function TradesPage() {
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
+  const [availableAssets, setAvailableAssets] = useState<string[]>([]);
+  const [isLoadingAssets, setIsLoadingAssets] = useState(true);
 
   const {
     items: trades,
@@ -55,10 +47,12 @@ export default function TradesPage() {
     page,
     selectedAccountId,
     dateRange,
+    selectedAssets,
     isNew,
     handlePageChange,
     handleAccountChange,
     handleDateRangeChange,
+    handleAssetChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<Trade, TradesAggregates>({
@@ -77,6 +71,21 @@ export default function TradesPage() {
       }
     };
     fetchAccounts();
+  }, []);
+
+  useEffect(() => {
+    const fetchAssets = async () => {
+      setIsLoadingAssets(true);
+      try {
+        const assets = await api.getDistinctBaseAssets("trades");
+        setAvailableAssets(assets);
+      } catch (error) {
+        console.error("Failed to fetch assets:", error);
+      } finally {
+        setIsLoadingAssets(false);
+      }
+    };
+    fetchAssets();
   }, []);
 
   const formatFees = (value: string) => {
@@ -120,6 +129,12 @@ export default function TradesPage() {
             {selectedAccountId === "all" ? "All Trades" : "Filtered Trades"}
           </CardTitle>
           <div className="flex items-center gap-4">
+            <AssetFilter
+              assets={availableAssets}
+              selectedAssets={selectedAssets}
+              onSelectionChange={handleAssetChange}
+              isLoading={isLoadingAssets}
+            />
             <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
             <Select value={selectedAccountId} onValueChange={handleAccountChange}>
               <SelectTrigger className="w-[280px]">

--- a/src/components/asset-filter.tsx
+++ b/src/components/asset-filter.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface AssetFilterProps {
+  assets: string[];
+  selectedAssets: string[];
+  onSelectionChange: (assets: string[]) => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export function AssetFilter({
+  assets,
+  selectedAssets,
+  onSelectionChange,
+  isLoading = false,
+  className,
+}: AssetFilterProps) {
+  const handleAssetToggle = (asset: string) => {
+    if (selectedAssets.includes(asset)) {
+      onSelectionChange(selectedAssets.filter((a) => a !== asset));
+    } else {
+      onSelectionChange([...selectedAssets, asset]);
+    }
+  };
+
+  const handleSelectAll = () => {
+    onSelectionChange([]);
+  };
+
+  const getButtonLabel = () => {
+    if (selectedAssets.length === 0) {
+      return "All Assets";
+    }
+    if (selectedAssets.length === 1) {
+      return selectedAssets[0];
+    }
+    return `${selectedAssets.length} assets`;
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant={selectedAssets.length > 0 ? "default" : "outline"}
+          size="sm"
+          className={cn("h-[34px] min-w-[120px] justify-between", className)}
+          disabled={isLoading}
+        >
+          <span>{isLoading ? "Loading..." : getButtonLabel()}</span>
+          <ChevronDown className="ml-2 h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[160px]">
+        <DropdownMenuLabel>Filter by Asset</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem
+          checked={selectedAssets.length === 0}
+          onCheckedChange={handleSelectAll}
+        >
+          All Assets
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        {assets.map((asset) => (
+          <DropdownMenuCheckboxItem
+            key={asset}
+            checked={selectedAssets.includes(asset)}
+            onCheckedChange={() => handleAssetToggle(asset)}
+          >
+            {asset}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/hooks/use-paginated-data.ts
+++ b/src/hooks/use-paginated-data.ts
@@ -5,6 +5,7 @@ import { useAutoRefresh } from "@/hooks/use-auto-refresh";
 import { useNewItems } from "@/hooks/use-new-items";
 import { useApi } from "@/hooks/use-api";
 import { DateRangeValue, getTimestampsFromDateRange } from "@/components/date-range-filter";
+import { DataFilters } from "@/lib/api";
 
 export interface PaginatedResult<T> {
   items: T[];
@@ -12,21 +13,15 @@ export interface PaginatedResult<T> {
 }
 
 export interface UsePaginatedDataConfig<TItem, TAggregates> {
-  /** Fetch items for the given page, account, and date range */
+  /** Fetch items for the given page and filters */
   fetchItems: (
     limit: number,
     offset: number,
-    accountId: string | undefined,
-    since: number | undefined,
-    until: number | undefined
+    filters: DataFilters
   ) => Promise<PaginatedResult<TItem>>;
 
-  /** Fetch aggregates for the given account and date range */
-  fetchAggregates: (
-    accountId: string | undefined,
-    since: number | undefined,
-    until: number | undefined
-  ) => Promise<TAggregates>;
+  /** Fetch aggregates for the given filters */
+  fetchAggregates: (filters: DataFilters) => Promise<TAggregates>;
 
   /** Fixed account ID for account-specific pages (undefined for global pages) */
   accountId?: string;
@@ -55,6 +50,7 @@ export interface UsePaginatedDataResult<TItem, TAggregates> {
   // Filters
   selectedAccountId: string;
   dateRange: DateRangeValue;
+  selectedAssets: string[];
 
   // New item tracking
   isNew: (id: string) => boolean;
@@ -63,6 +59,7 @@ export interface UsePaginatedDataResult<TItem, TAggregates> {
   handlePageChange: (newPage: number) => void;
   handleAccountChange: (accountId: string) => void;
   handleDateRangeChange: (newRange: DateRangeValue) => void;
+  handleAssetChange: (assets: string[]) => void;
 
   // Refresh
   refresh: () => void;
@@ -98,6 +95,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   const [page, setPage] = useState(0);
   const [selectedAccountId, setSelectedAccountId] = useState<string>(accountId ?? "all");
   const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
+  const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
 
   // New item tracking
   const { updateItems: updateNewItems, isNew } = useNewItems<TItem>();
@@ -106,24 +104,37 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   const pageRef = useRef(page);
   const selectedAccountIdRef = useRef(selectedAccountId);
   const dateRangeRef = useRef(dateRange);
+  const selectedAssetsRef = useRef(selectedAssets);
 
   useEffect(() => {
     pageRef.current = page;
     selectedAccountIdRef.current = selectedAccountId;
     dateRangeRef.current = dateRange;
-  }, [page, selectedAccountId, dateRange]);
+    selectedAssetsRef.current = selectedAssets;
+  }, [page, selectedAccountId, dateRange, selectedAssets]);
+
+  // Build filters object from current state
+  const buildFilters = useCallback(
+    (accId: string, dateRangeValue: DateRangeValue, assets: string[]): DataFilters => {
+      const { since, until } = getTimestampsFromDateRange(dateRangeValue);
+      return {
+        accountId: accId === "all" ? undefined : accId,
+        since,
+        until,
+        baseAssets: assets.length > 0 ? assets : undefined,
+      };
+    },
+    []
+  );
 
   // Fetch aggregates
   const doFetchAggregates = useCallback(
-    async (accId: string, dateRangeValue: DateRangeValue) => {
+    async (accId: string, dateRangeValue: DateRangeValue, assets: string[]) => {
       setIsLoadingAggregates(true);
-      const { since, until } = getTimestampsFromDateRange(dateRangeValue);
-      const effectiveAccountId = accId === "all" ? undefined : accId;
+      const filters = buildFilters(accId, dateRangeValue, assets);
 
       try {
-        const data = await withErrorReporting(() =>
-          fetchAggregates(effectiveAccountId, since, until)
-        );
+        const data = await withErrorReporting(() => fetchAggregates(filters));
         setAggregates(data);
       } catch (error) {
         console.error("Failed to fetch aggregates:", error);
@@ -131,19 +142,18 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
         setIsLoadingAggregates(false);
       }
     },
-    [fetchAggregates, withErrorReporting]
+    [fetchAggregates, withErrorReporting, buildFilters]
   );
 
   // Fetch items
   const doFetchItems = useCallback(
-    async (pageNum: number, accId: string, dateRangeValue: DateRangeValue) => {
+    async (pageNum: number, accId: string, dateRangeValue: DateRangeValue, assets: string[]) => {
       setIsLoading(true);
-      const { since, until } = getTimestampsFromDateRange(dateRangeValue);
-      const effectiveAccountId = accId === "all" ? undefined : accId;
+      const filters = buildFilters(accId, dateRangeValue, assets);
 
       try {
         const data = await withErrorReporting(() =>
-          fetchItems(pageSize, pageNum * pageSize, effectiveAccountId, since, until)
+          fetchItems(pageSize, pageNum * pageSize, filters)
         );
         setItems(data.items);
         setTotalCount(data.totalCount);
@@ -154,14 +164,23 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
         setIsLoading(false);
       }
     },
-    [fetchItems, pageSize, withErrorReporting, updateNewItems]
+    [fetchItems, pageSize, withErrorReporting, updateNewItems, buildFilters]
   );
 
   // Combined fetch for auto-refresh
   const fetchAllData = useCallback(async () => {
     await Promise.all([
-      doFetchItems(pageRef.current, selectedAccountIdRef.current, dateRangeRef.current),
-      doFetchAggregates(selectedAccountIdRef.current, dateRangeRef.current),
+      doFetchItems(
+        pageRef.current,
+        selectedAccountIdRef.current,
+        dateRangeRef.current,
+        selectedAssetsRef.current
+      ),
+      doFetchAggregates(
+        selectedAccountIdRef.current,
+        dateRangeRef.current,
+        selectedAssetsRef.current
+      ),
     ]);
   }, [doFetchItems, doFetchAggregates]);
 
@@ -178,7 +197,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   // Refetch when filters change
   useEffect(() => {
     refresh();
-  }, [page, selectedAccountId, dateRange]);
+  }, [page, selectedAccountId, dateRange, selectedAssets]);
 
   // If accountId prop changes (for account-specific pages), update filter
   useEffect(() => {
@@ -202,6 +221,11 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
     setPage(0);
   }, []);
 
+  const handleAssetChange = useCallback((assets: string[]) => {
+    setSelectedAssets(assets);
+    setPage(0);
+  }, []);
+
   return {
     // Data
     items,
@@ -219,6 +243,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
     // Filters
     selectedAccountId,
     dateRange,
+    selectedAssets,
 
     // New item tracking
     isNew,
@@ -227,6 +252,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
     handlePageChange,
     handleAccountChange,
     handleDateRangeChange,
+    handleAssetChange,
 
     // Refresh
     refresh,

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -7,42 +7,12 @@ import {
   GET_ACCOUNT_BY_ID,
   CREATE_ACCOUNT,
   DELETE_ACCOUNT,
-  GET_TRADES,
-  GET_TRADES_WITH_FILTER,
-  GET_TRADES_WITH_RANGE_FILTER,
-  GET_TRADES_BY_ACCOUNT,
-  GET_TRADES_BY_ACCOUNT_WITH_FILTER,
-  GET_TRADES_BY_ACCOUNT_WITH_RANGE_FILTER,
-  GET_TRADES_COUNT,
-  GET_TRADES_COUNT_WITH_FILTER,
-  GET_TRADES_COUNT_WITH_RANGE_FILTER,
-  GET_TRADES_COUNT_BY_ACCOUNT,
-  GET_TRADES_COUNT_BY_ACCOUNT_WITH_FILTER,
-  GET_TRADES_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER,
-  GET_TRADES_AGGREGATES,
-  GET_TRADES_AGGREGATES_WITH_FILTER,
-  GET_TRADES_AGGREGATES_WITH_RANGE_FILTER,
-  GET_TRADES_AGGREGATES_BY_ACCOUNT,
-  GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_FILTER,
-  GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER,
-  GET_FUNDING_PAYMENTS,
-  GET_FUNDING_PAYMENTS_WITH_FILTER,
-  GET_FUNDING_PAYMENTS_WITH_RANGE_FILTER,
-  GET_FUNDING_PAYMENTS_BY_ACCOUNT,
-  GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_FILTER,
-  GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_RANGE_FILTER,
-  GET_FUNDING_PAYMENTS_COUNT,
-  GET_FUNDING_PAYMENTS_COUNT_WITH_FILTER,
-  GET_FUNDING_PAYMENTS_COUNT_WITH_RANGE_FILTER,
-  GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT,
-  GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_FILTER,
-  GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER,
-  GET_FUNDING_AGGREGATES,
-  GET_FUNDING_AGGREGATES_WITH_FILTER,
-  GET_FUNDING_AGGREGATES_WITH_RANGE_FILTER,
-  GET_FUNDING_AGGREGATES_BY_ACCOUNT,
-  GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_FILTER,
-  GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER,
+  GET_DISTINCT_TRADE_ASSETS,
+  GET_DISTINCT_FUNDING_ASSETS,
+  GET_TRADES_DYNAMIC,
+  GET_TRADES_AGGREGATES_DYNAMIC,
+  GET_FUNDING_PAYMENTS_DYNAMIC,
+  GET_FUNDING_AGGREGATES_DYNAMIC,
   Exchange,
   ExchangeAccount,
   ExchangeAccountType,
@@ -51,17 +21,15 @@ import {
   FundingPayment,
   FundingAggregates,
 } from "../queries";
-import { ApiClient, CreateAccountInput, TradesResult, FundingPaymentsResult } from "./types";
+import { ApiClient, CreateAccountInput, TradesResult, FundingPaymentsResult, DataFilters } from "./types";
 import { ApiError } from "./errors";
 
 function isAuthError(error: unknown): boolean {
   if (error && typeof error === "object" && "response" in error) {
     const response = (error as { response: { status?: number; errors?: { extensions?: { code?: string } }[] } }).response;
-    // Check for HTTP 401/403
     if (response?.status === 401 || response?.status === 403) {
       return true;
     }
-    // Check for Hasura access-denied error
     if (response?.errors) {
       return response.errors.some(
         (e) => e.extensions?.code === "access-denied"
@@ -86,9 +54,66 @@ async function withErrorHandling<T>(fn: () => Promise<T>): Promise<T> {
     if (isAuthError(error)) {
       handleAuthError();
     }
-    // Convert to typed ApiError
     throw ApiError.fromError(error);
   }
+}
+
+// Build where clause for trades based on filters
+function buildTradesWhereClause(filters?: DataFilters): Record<string, unknown> {
+  const conditions: Record<string, unknown>[] = [];
+
+  if (filters?.accountId) {
+    conditions.push({ exchange_account_id: { _eq: filters.accountId } });
+  }
+
+  if (filters?.since !== undefined && filters?.until !== undefined) {
+    conditions.push({ timestamp: { _gte: String(filters.since), _lte: String(filters.until) } });
+  } else if (filters?.since !== undefined) {
+    conditions.push({ timestamp: { _gte: String(filters.since) } });
+  }
+
+  if (filters?.baseAssets && filters.baseAssets.length > 0) {
+    conditions.push({ base_asset: { _in: filters.baseAssets } });
+  }
+
+  if (conditions.length === 0) {
+    return {};
+  }
+
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
+
+  return { _and: conditions };
+}
+
+// Build where clause for funding payments based on filters
+function buildFundingWhereClause(filters?: DataFilters): Record<string, unknown> {
+  const conditions: Record<string, unknown>[] = [];
+
+  if (filters?.accountId) {
+    conditions.push({ exchange_account_id: { _eq: filters.accountId } });
+  }
+
+  if (filters?.since !== undefined && filters?.until !== undefined) {
+    conditions.push({ timestamp: { _gte: String(filters.since), _lte: String(filters.until) } });
+  } else if (filters?.since !== undefined) {
+    conditions.push({ timestamp: { _gte: String(filters.since) } });
+  }
+
+  if (filters?.baseAssets && filters.baseAssets.length > 0) {
+    conditions.push({ base_asset: { _in: filters.baseAssets } });
+  }
+
+  if (conditions.length === 0) {
+    return {};
+  }
+
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
+
+  return { _and: conditions };
 }
 
 export const graphqlApi: ApiClient = {
@@ -147,138 +172,40 @@ export const graphqlApi: ApiClient = {
     });
   },
 
-  async getTrades(limit: number, offset: number, since?: number, until?: number): Promise<TradesResult> {
+  async getDistinctBaseAssets(type: "trades" | "funding"): Promise<string[]> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
-
-      // Use different queries based on whether filter is provided
-      // Hasura doesn't handle null properly in _gte/_lte comparisons
-      if (since !== undefined && until !== undefined) {
-        // Range filter (custom date range)
-        const sinceBigint = String(since);
-        const untilBigint = String(until);
-        const [tradesData, countData] = await Promise.all([
-          client.request<{ trades: Trade[] }>(GET_TRADES_WITH_RANGE_FILTER, { limit, offset, since: sinceBigint, until: untilBigint }),
-          client.request<{
-            trades_aggregate: { aggregate: { count: number } };
-          }>(GET_TRADES_COUNT_WITH_RANGE_FILTER, { since: sinceBigint, until: untilBigint }),
-        ]);
-        return {
-          trades: tradesData.trades,
-          totalCount: countData.trades_aggregate.aggregate.count,
-        };
-      } else if (since !== undefined) {
-        // Since-only filter (presets like 24h, 7d, etc.)
-        const sinceBigint = String(since);
-        const [tradesData, countData] = await Promise.all([
-          client.request<{ trades: Trade[] }>(GET_TRADES_WITH_FILTER, { limit, offset, since: sinceBigint }),
-          client.request<{
-            trades_aggregate: { aggregate: { count: number } };
-          }>(GET_TRADES_COUNT_WITH_FILTER, { since: sinceBigint }),
-        ]);
-        return {
-          trades: tradesData.trades,
-          totalCount: countData.trades_aggregate.aggregate.count,
-        };
+      if (type === "trades") {
+        const data = await client.request<{ trades: { base_asset: string }[] }>(GET_DISTINCT_TRADE_ASSETS);
+        return data.trades.map((t) => t.base_asset);
       } else {
-        // No filter
-        const [tradesData, countData] = await Promise.all([
-          client.request<{ trades: Trade[] }>(GET_TRADES, { limit, offset }),
-          client.request<{
-            trades_aggregate: { aggregate: { count: number } };
-          }>(GET_TRADES_COUNT, {}),
-        ]);
-        return {
-          trades: tradesData.trades,
-          totalCount: countData.trades_aggregate.aggregate.count,
-        };
+        const data = await client.request<{ funding_payments: { base_asset: string }[] }>(GET_DISTINCT_FUNDING_ASSETS);
+        return data.funding_payments.map((f) => f.base_asset);
       }
     });
   },
 
-  async getTradesByAccount(
-    accountId: string,
-    limit: number,
-    offset: number,
-    since?: number,
-    until?: number
-  ): Promise<TradesResult> {
+  async getTrades(limit: number, offset: number, filters?: DataFilters): Promise<TradesResult> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
+      const where = buildTradesWhereClause(filters);
 
-      // Use different queries based on whether filter is provided
-      if (since !== undefined && until !== undefined) {
-        const sinceBigint = String(since);
-        const untilBigint = String(until);
-        const [tradesData, countData] = await Promise.all([
-          client.request<{ trades: Trade[] }>(GET_TRADES_BY_ACCOUNT_WITH_RANGE_FILTER, {
-            accountId,
-            limit,
-            offset,
-            since: sinceBigint,
-            until: untilBigint,
-          }),
-          client.request<{
-            trades_aggregate: { aggregate: { count: number } };
-          }>(GET_TRADES_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER, { accountId, since: sinceBigint, until: untilBigint }),
-        ]);
-        return {
-          trades: tradesData.trades,
-          totalCount: countData.trades_aggregate.aggregate.count,
-        };
-      } else if (since !== undefined) {
-        const sinceBigint = String(since);
-        const [tradesData, countData] = await Promise.all([
-          client.request<{ trades: Trade[] }>(GET_TRADES_BY_ACCOUNT_WITH_FILTER, {
-            accountId,
-            limit,
-            offset,
-            since: sinceBigint,
-          }),
-          client.request<{
-            trades_aggregate: { aggregate: { count: number } };
-          }>(GET_TRADES_COUNT_BY_ACCOUNT_WITH_FILTER, { accountId, since: sinceBigint }),
-        ]);
-        return {
-          trades: tradesData.trades,
-          totalCount: countData.trades_aggregate.aggregate.count,
-        };
-      } else {
-        const [tradesData, countData] = await Promise.all([
-          client.request<{ trades: Trade[] }>(GET_TRADES_BY_ACCOUNT, {
-            accountId,
-            limit,
-            offset,
-          }),
-          client.request<{
-            trades_aggregate: { aggregate: { count: number } };
-          }>(GET_TRADES_COUNT_BY_ACCOUNT, { accountId }),
-        ]);
-        return {
-          trades: tradesData.trades,
-          totalCount: countData.trades_aggregate.aggregate.count,
-        };
-      }
+      const data = await client.request<{
+        trades: Trade[];
+        trades_aggregate: { aggregate: { count: number } };
+      }>(GET_TRADES_DYNAMIC, { limit, offset, where });
+
+      return {
+        trades: data.trades,
+        totalCount: data.trades_aggregate.aggregate.count,
+      };
     });
   },
 
-  async getTradesAggregates(since?: number, until?: number): Promise<TradesAggregates> {
+  async getTradesAggregates(filters?: DataFilters): Promise<TradesAggregates> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
-
-      // Use different queries based on whether filter is provided
-      let query;
-      let variables: Record<string, string> = {};
-
-      if (since !== undefined && until !== undefined) {
-        query = GET_TRADES_AGGREGATES_WITH_RANGE_FILTER;
-        variables = { since: String(since), until: String(until) };
-      } else if (since !== undefined) {
-        query = GET_TRADES_AGGREGATES_WITH_FILTER;
-        variables = { since: String(since) };
-      } else {
-        query = GET_TRADES_AGGREGATES;
-      }
+      const where = buildTradesWhereClause(filters);
 
       const data = await client.request<{
         trades_aggregate: {
@@ -287,7 +214,7 @@ export const graphqlApi: ApiClient = {
             sum: { fee: string | null };
           };
         };
-      }>(query, variables);
+      }>(GET_TRADES_AGGREGATES_DYNAMIC, { where });
 
       return {
         totalFees: data.trades_aggregate.aggregate.sum.fee || "0",
@@ -297,170 +224,27 @@ export const graphqlApi: ApiClient = {
     });
   },
 
-  async getTradesAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<TradesAggregates> {
+  async getFundingPayments(limit: number, offset: number, filters?: DataFilters): Promise<FundingPaymentsResult> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
-
-      // Use different queries based on whether filter is provided
-      let query;
-      let variables: Record<string, string> = { accountId };
-
-      if (since !== undefined && until !== undefined) {
-        query = GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER;
-        variables = { accountId, since: String(since), until: String(until) };
-      } else if (since !== undefined) {
-        query = GET_TRADES_AGGREGATES_BY_ACCOUNT_WITH_FILTER;
-        variables = { accountId, since: String(since) };
-      } else {
-        query = GET_TRADES_AGGREGATES_BY_ACCOUNT;
-      }
+      const where = buildFundingWhereClause(filters);
 
       const data = await client.request<{
-        trades_aggregate: {
-          aggregate: {
-            count: number;
-            sum: { fee: string | null };
-          };
-        };
-      }>(query, variables);
+        funding_payments: FundingPayment[];
+        funding_payments_aggregate: { aggregate: { count: number } };
+      }>(GET_FUNDING_PAYMENTS_DYNAMIC, { limit, offset, where });
 
       return {
-        totalFees: data.trades_aggregate.aggregate.sum.fee || "0",
-        totalVolume: "0",
-        count: data.trades_aggregate.aggregate.count,
+        fundingPayments: data.funding_payments,
+        totalCount: data.funding_payments_aggregate.aggregate.count,
       };
     });
   },
 
-  async getFundingPayments(limit: number, offset: number, since?: number, until?: number): Promise<FundingPaymentsResult> {
+  async getFundingAggregates(filters?: DataFilters): Promise<FundingAggregates> {
     return withErrorHandling(async () => {
       const client = getGraphQLClient();
-
-      // Use different queries based on whether filter is provided
-      // Hasura doesn't accept null for bigint _gte/_lte comparisons
-      if (since !== undefined && until !== undefined) {
-        const sinceBigint = String(since);
-        const untilBigint = String(until);
-        const [fundingData, countData] = await Promise.all([
-          client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_WITH_RANGE_FILTER, { limit, offset, since: sinceBigint, until: untilBigint }),
-          client.request<{
-            funding_payments_aggregate: { aggregate: { count: number } };
-          }>(GET_FUNDING_PAYMENTS_COUNT_WITH_RANGE_FILTER, { since: sinceBigint, until: untilBigint }),
-        ]);
-        return {
-          fundingPayments: fundingData.funding_payments,
-          totalCount: countData.funding_payments_aggregate.aggregate.count,
-        };
-      } else if (since !== undefined) {
-        const sinceBigint = String(since);
-        const [fundingData, countData] = await Promise.all([
-          client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_WITH_FILTER, { limit, offset, since: sinceBigint }),
-          client.request<{
-            funding_payments_aggregate: { aggregate: { count: number } };
-          }>(GET_FUNDING_PAYMENTS_COUNT_WITH_FILTER, { since: sinceBigint }),
-        ]);
-        return {
-          fundingPayments: fundingData.funding_payments,
-          totalCount: countData.funding_payments_aggregate.aggregate.count,
-        };
-      } else {
-        const [fundingData, countData] = await Promise.all([
-          client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS, { limit, offset }),
-          client.request<{
-            funding_payments_aggregate: { aggregate: { count: number } };
-          }>(GET_FUNDING_PAYMENTS_COUNT, {}),
-        ]);
-        return {
-          fundingPayments: fundingData.funding_payments,
-          totalCount: countData.funding_payments_aggregate.aggregate.count,
-        };
-      }
-    });
-  },
-
-  async getFundingPaymentsByAccount(
-    accountId: string,
-    limit: number,
-    offset: number,
-    since?: number,
-    until?: number
-  ): Promise<FundingPaymentsResult> {
-    return withErrorHandling(async () => {
-      const client = getGraphQLClient();
-
-      // Use different queries based on whether filter is provided
-      if (since !== undefined && until !== undefined) {
-        const sinceBigint = String(since);
-        const untilBigint = String(until);
-        const [fundingData, countData] = await Promise.all([
-          client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_RANGE_FILTER, {
-            accountId,
-            limit,
-            offset,
-            since: sinceBigint,
-            until: untilBigint,
-          }),
-          client.request<{
-            funding_payments_aggregate: { aggregate: { count: number } };
-          }>(GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_RANGE_FILTER, { accountId, since: sinceBigint, until: untilBigint }),
-        ]);
-        return {
-          fundingPayments: fundingData.funding_payments,
-          totalCount: countData.funding_payments_aggregate.aggregate.count,
-        };
-      } else if (since !== undefined) {
-        const sinceBigint = String(since);
-        const [fundingData, countData] = await Promise.all([
-          client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_BY_ACCOUNT_WITH_FILTER, {
-            accountId,
-            limit,
-            offset,
-            since: sinceBigint,
-          }),
-          client.request<{
-            funding_payments_aggregate: { aggregate: { count: number } };
-          }>(GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT_WITH_FILTER, { accountId, since: sinceBigint }),
-        ]);
-        return {
-          fundingPayments: fundingData.funding_payments,
-          totalCount: countData.funding_payments_aggregate.aggregate.count,
-        };
-      } else {
-        const [fundingData, countData] = await Promise.all([
-          client.request<{ funding_payments: FundingPayment[] }>(GET_FUNDING_PAYMENTS_BY_ACCOUNT, {
-            accountId,
-            limit,
-            offset,
-          }),
-          client.request<{
-            funding_payments_aggregate: { aggregate: { count: number } };
-          }>(GET_FUNDING_PAYMENTS_COUNT_BY_ACCOUNT, { accountId }),
-        ]);
-        return {
-          fundingPayments: fundingData.funding_payments,
-          totalCount: countData.funding_payments_aggregate.aggregate.count,
-        };
-      }
-    });
-  },
-
-  async getFundingAggregates(since?: number, until?: number): Promise<FundingAggregates> {
-    return withErrorHandling(async () => {
-      const client = getGraphQLClient();
-
-      // Use different queries based on whether filter is provided
-      let query;
-      let variables: Record<string, string> = {};
-
-      if (since !== undefined && until !== undefined) {
-        query = GET_FUNDING_AGGREGATES_WITH_RANGE_FILTER;
-        variables = { since: String(since), until: String(until) };
-      } else if (since !== undefined) {
-        query = GET_FUNDING_AGGREGATES_WITH_FILTER;
-        variables = { since: String(since) };
-      } else {
-        query = GET_FUNDING_AGGREGATES;
-      }
+      const where = buildFundingWhereClause(filters);
 
       const data = await client.request<{
         funding_payments_aggregate: {
@@ -469,41 +253,7 @@ export const graphqlApi: ApiClient = {
             sum: { amount: string | null };
           };
         };
-      }>(query, variables);
-
-      return {
-        totalAmount: data.funding_payments_aggregate.aggregate.sum.amount || "0",
-        count: data.funding_payments_aggregate.aggregate.count,
-      };
-    });
-  },
-
-  async getFundingAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<FundingAggregates> {
-    return withErrorHandling(async () => {
-      const client = getGraphQLClient();
-
-      // Use different queries based on whether filter is provided
-      let query;
-      let variables: Record<string, string> = { accountId };
-
-      if (since !== undefined && until !== undefined) {
-        query = GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER;
-        variables = { accountId, since: String(since), until: String(until) };
-      } else if (since !== undefined) {
-        query = GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_FILTER;
-        variables = { accountId, since: String(since) };
-      } else {
-        query = GET_FUNDING_AGGREGATES_BY_ACCOUNT;
-      }
-
-      const data = await client.request<{
-        funding_payments_aggregate: {
-          aggregate: {
-            count: number;
-            sum: { amount: string | null };
-          };
-        };
-      }>(query, variables);
+      }>(GET_FUNDING_AGGREGATES_DYNAMIC, { where });
 
       return {
         totalAmount: data.funding_payments_aggregate.aggregate.sum.amount || "0",

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -7,4 +7,4 @@ const USE_MOCK_API = process.env.NEXT_PUBLIC_USE_MOCK_API === "true";
 export const api: ApiClient = USE_MOCK_API ? mockApi : graphqlApi;
 
 // Re-export types for convenience
-export type { ApiClient, CreateAccountInput, TradesResult } from "./types";
+export type { ApiClient, CreateAccountInput, TradesResult, DataFilters } from "./types";

--- a/src/lib/api/mock.ts
+++ b/src/lib/api/mock.ts
@@ -1,5 +1,5 @@
 import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates } from "../queries";
-import { ApiClient, CreateAccountInput, TradesResult, FundingPaymentsResult } from "./types";
+import { ApiClient, CreateAccountInput, TradesResult, FundingPaymentsResult, DataFilters } from "./types";
 
 // Mock exchanges
 const mockExchanges: Exchange[] = [
@@ -184,6 +184,52 @@ const mockFundingPayments: FundingPayment[] = [
 // Simulate network delay
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// Filter trades based on DataFilters
+function filterTrades(trades: Trade[], filters?: DataFilters): Trade[] {
+  let result = trades;
+
+  if (filters?.accountId) {
+    result = result.filter((trade) => trade.exchange_account_id === filters.accountId);
+  }
+
+  if (filters?.since) {
+    result = result.filter((trade) => new Date(trade.timestamp).getTime() >= filters.since!);
+  }
+
+  if (filters?.until) {
+    result = result.filter((trade) => new Date(trade.timestamp).getTime() <= filters.until!);
+  }
+
+  if (filters?.baseAssets && filters.baseAssets.length > 0) {
+    result = result.filter((trade) => filters.baseAssets!.includes(trade.base_asset));
+  }
+
+  return result;
+}
+
+// Filter funding payments based on DataFilters
+function filterFundingPayments(payments: FundingPayment[], filters?: DataFilters): FundingPayment[] {
+  let result = payments;
+
+  if (filters?.accountId) {
+    result = result.filter((payment) => payment.exchange_account_id === filters.accountId);
+  }
+
+  if (filters?.since) {
+    result = result.filter((payment) => payment.timestamp >= filters.since!);
+  }
+
+  if (filters?.until) {
+    result = result.filter((payment) => payment.timestamp <= filters.until!);
+  }
+
+  if (filters?.baseAssets && filters.baseAssets.length > 0) {
+    result = result.filter((payment) => filters.baseAssets!.includes(payment.base_asset));
+  }
+
+  return result;
+}
+
 export const mockApi: ApiClient = {
   async getExchanges(): Promise<Exchange[]> {
     await delay(200);
@@ -246,16 +292,20 @@ export const mockApi: ApiClient = {
     return { id };
   },
 
-  async getTrades(limit: number, offset: number, since?: number, until?: number): Promise<TradesResult> {
+  async getDistinctBaseAssets(type: "trades" | "funding"): Promise<string[]> {
+    await delay(200);
+    if (type === "trades") {
+      const assets = [...new Set(mockTrades.map((t) => t.base_asset))];
+      return assets.sort();
+    } else {
+      const assets = [...new Set(mockFundingPayments.map((f) => f.base_asset))];
+      return assets.sort();
+    }
+  },
+
+  async getTrades(limit: number, offset: number, filters?: DataFilters): Promise<TradesResult> {
     await delay(300);
-    // Filter by timestamp if since/until is provided
-    let filteredTrades = mockTrades;
-    if (since) {
-      filteredTrades = filteredTrades.filter((trade) => new Date(trade.timestamp).getTime() >= since);
-    }
-    if (until) {
-      filteredTrades = filteredTrades.filter((trade) => new Date(trade.timestamp).getTime() <= until);
-    }
+    const filteredTrades = filterTrades(mockTrades, filters);
     const paginatedTrades = filteredTrades.slice(offset, offset + limit);
     return {
       trades: paginatedTrades,
@@ -263,45 +313,9 @@ export const mockApi: ApiClient = {
     };
   },
 
-  async getTradesByAccount(
-    accountId: string,
-    limit: number,
-    offset: number,
-    since?: number,
-    until?: number
-  ): Promise<TradesResult> {
-    await delay(300);
-    let accountTrades = mockTrades.filter(
-      (trade) => trade.exchange_account_id === accountId
-    );
-    // Filter by timestamp if since/until is provided
-    if (since) {
-      accountTrades = accountTrades.filter(
-        (trade) => new Date(trade.timestamp).getTime() >= since
-      );
-    }
-    if (until) {
-      accountTrades = accountTrades.filter(
-        (trade) => new Date(trade.timestamp).getTime() <= until
-      );
-    }
-    const paginatedTrades = accountTrades.slice(offset, offset + limit);
-    return {
-      trades: paginatedTrades,
-      totalCount: accountTrades.length,
-    };
-  },
-
-  async getTradesAggregates(since?: number, until?: number): Promise<TradesAggregates> {
+  async getTradesAggregates(filters?: DataFilters): Promise<TradesAggregates> {
     await delay(200);
-    // Filter by timestamp if since/until is provided
-    let filteredTrades = mockTrades;
-    if (since) {
-      filteredTrades = filteredTrades.filter((trade) => new Date(trade.timestamp).getTime() >= since);
-    }
-    if (until) {
-      filteredTrades = filteredTrades.filter((trade) => new Date(trade.timestamp).getTime() <= until);
-    }
+    const filteredTrades = filterTrades(mockTrades, filters);
     const totalFees = filteredTrades.reduce(
       (sum, trade) => sum + parseFloat(trade.fee),
       0
@@ -313,43 +327,9 @@ export const mockApi: ApiClient = {
     };
   },
 
-  async getTradesAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<TradesAggregates> {
-    await delay(200);
-    let accountTrades = mockTrades.filter(
-      (trade) => trade.exchange_account_id === accountId
-    );
-    // Filter by timestamp if since/until is provided
-    if (since) {
-      accountTrades = accountTrades.filter(
-        (trade) => new Date(trade.timestamp).getTime() >= since
-      );
-    }
-    if (until) {
-      accountTrades = accountTrades.filter(
-        (trade) => new Date(trade.timestamp).getTime() <= until
-      );
-    }
-    const totalFees = accountTrades.reduce(
-      (sum, trade) => sum + parseFloat(trade.fee),
-      0
-    );
-    return {
-      totalFees: totalFees.toString(),
-      totalVolume: "0",
-      count: accountTrades.length,
-    };
-  },
-
-  async getFundingPayments(limit: number, offset: number, since?: number, until?: number): Promise<FundingPaymentsResult> {
+  async getFundingPayments(limit: number, offset: number, filters?: DataFilters): Promise<FundingPaymentsResult> {
     await delay(300);
-    // Filter by timestamp if since/until is provided (funding payments use unix ms)
-    let filteredPayments = mockFundingPayments;
-    if (since) {
-      filteredPayments = filteredPayments.filter((payment) => payment.timestamp >= since);
-    }
-    if (until) {
-      filteredPayments = filteredPayments.filter((payment) => payment.timestamp <= until);
-    }
+    const filteredPayments = filterFundingPayments(mockFundingPayments, filters);
     const paginatedPayments = filteredPayments.slice(offset, offset + limit);
     return {
       fundingPayments: paginatedPayments,
@@ -357,45 +337,9 @@ export const mockApi: ApiClient = {
     };
   },
 
-  async getFundingPaymentsByAccount(
-    accountId: string,
-    limit: number,
-    offset: number,
-    since?: number,
-    until?: number
-  ): Promise<FundingPaymentsResult> {
-    await delay(300);
-    let accountPayments = mockFundingPayments.filter(
-      (payment) => payment.exchange_account_id === accountId
-    );
-    // Filter by timestamp if since/until is provided
-    if (since) {
-      accountPayments = accountPayments.filter(
-        (payment) => payment.timestamp >= since
-      );
-    }
-    if (until) {
-      accountPayments = accountPayments.filter(
-        (payment) => payment.timestamp <= until
-      );
-    }
-    const paginatedPayments = accountPayments.slice(offset, offset + limit);
-    return {
-      fundingPayments: paginatedPayments,
-      totalCount: accountPayments.length,
-    };
-  },
-
-  async getFundingAggregates(since?: number, until?: number): Promise<FundingAggregates> {
+  async getFundingAggregates(filters?: DataFilters): Promise<FundingAggregates> {
     await delay(200);
-    // Filter by timestamp if since/until is provided
-    let filteredPayments = mockFundingPayments;
-    if (since) {
-      filteredPayments = filteredPayments.filter((payment) => payment.timestamp >= since);
-    }
-    if (until) {
-      filteredPayments = filteredPayments.filter((payment) => payment.timestamp <= until);
-    }
+    const filteredPayments = filterFundingPayments(mockFundingPayments, filters);
     const totalAmount = filteredPayments.reduce(
       (sum, payment) => sum + parseFloat(payment.amount),
       0
@@ -403,32 +347,6 @@ export const mockApi: ApiClient = {
     return {
       totalAmount: totalAmount.toString(),
       count: filteredPayments.length,
-    };
-  },
-
-  async getFundingAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<FundingAggregates> {
-    await delay(200);
-    let accountPayments = mockFundingPayments.filter(
-      (payment) => payment.exchange_account_id === accountId
-    );
-    // Filter by timestamp if since/until is provided
-    if (since) {
-      accountPayments = accountPayments.filter(
-        (payment) => payment.timestamp >= since
-      );
-    }
-    if (until) {
-      accountPayments = accountPayments.filter(
-        (payment) => payment.timestamp <= until
-      );
-    }
-    const totalAmount = accountPayments.reduce(
-      (sum, payment) => sum + parseFloat(payment.amount),
-      0
-    );
-    return {
-      totalAmount: totalAmount.toString(),
-      count: accountPayments.length,
     };
   },
 };

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -17,6 +17,13 @@ export interface FundingPaymentsResult {
   totalCount: number;
 }
 
+export interface DataFilters {
+  accountId?: string;
+  since?: number;
+  until?: number;
+  baseAssets?: string[];
+}
+
 export interface ApiClient {
   getExchanges(): Promise<Exchange[]>;
   getAccountTypes(): Promise<ExchangeAccountType[]>;
@@ -24,24 +31,9 @@ export interface ApiClient {
   getAccountById(id: string): Promise<ExchangeAccount | null>;
   createAccount(input: CreateAccountInput): Promise<ExchangeAccount>;
   deleteAccount(id: string): Promise<{ id: string }>;
-  getTrades(limit: number, offset: number, since?: number, until?: number): Promise<TradesResult>;
-  getTradesByAccount(
-    accountId: string,
-    limit: number,
-    offset: number,
-    since?: number,
-    until?: number
-  ): Promise<TradesResult>;
-  getTradesAggregates(since?: number, until?: number): Promise<TradesAggregates>;
-  getTradesAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<TradesAggregates>;
-  getFundingPayments(limit: number, offset: number, since?: number, until?: number): Promise<FundingPaymentsResult>;
-  getFundingPaymentsByAccount(
-    accountId: string,
-    limit: number,
-    offset: number,
-    since?: number,
-    until?: number
-  ): Promise<FundingPaymentsResult>;
-  getFundingAggregates(since?: number, until?: number): Promise<FundingAggregates>;
-  getFundingAggregatesByAccount(accountId: string, since?: number, until?: number): Promise<FundingAggregates>;
+  getDistinctBaseAssets(type: "trades" | "funding"): Promise<string[]>;
+  getTrades(limit: number, offset: number, filters?: DataFilters): Promise<TradesResult>;
+  getTradesAggregates(filters?: DataFilters): Promise<TradesAggregates>;
+  getFundingPayments(limit: number, offset: number, filters?: DataFilters): Promise<FundingPaymentsResult>;
+  getFundingAggregates(filters?: DataFilters): Promise<FundingAggregates>;
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -786,3 +786,109 @@ export const GET_FUNDING_AGGREGATES_BY_ACCOUNT_WITH_RANGE_FILTER = gql`
     }
   }
 `;
+
+// Distinct base assets queries
+export const GET_DISTINCT_TRADE_ASSETS = gql`
+  query GetDistinctTradeAssets {
+    trades(distinct_on: base_asset, order_by: { base_asset: asc }) {
+      base_asset
+    }
+  }
+`;
+
+export const GET_DISTINCT_FUNDING_ASSETS = gql`
+  query GetDistinctFundingAssets {
+    funding_payments(distinct_on: base_asset, order_by: { base_asset: asc }) {
+      base_asset
+    }
+  }
+`;
+
+// Dynamic filter queries - accept where clause as variable
+export const GET_TRADES_DYNAMIC = gql`
+  query GetTradesDynamic($limit: Int!, $offset: Int!, $where: trades_bool_exp!) {
+    trades(limit: $limit, offset: $offset, order_by: { timestamp: desc }, where: $where) {
+      id
+      base_asset
+      quote_asset
+      side
+      price
+      quantity
+      timestamp
+      fee
+      order_id
+      trade_id
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+    trades_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export const GET_TRADES_AGGREGATES_DYNAMIC = gql`
+  query GetTradesAggregatesDynamic($where: trades_bool_exp!) {
+    trades_aggregate(where: $where) {
+      aggregate {
+        count
+        sum {
+          fee
+        }
+      }
+    }
+  }
+`;
+
+export const GET_FUNDING_PAYMENTS_DYNAMIC = gql`
+  query GetFundingPaymentsDynamic($limit: Int!, $offset: Int!, $where: funding_payments_bool_exp!) {
+    funding_payments(limit: $limit, offset: $offset, order_by: { timestamp: desc }, where: $where) {
+      id
+      base_asset
+      quote_asset
+      amount
+      timestamp
+      payment_id
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+    funding_payments_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export const GET_FUNDING_AGGREGATES_DYNAMIC = gql`
+  query GetFundingAggregatesDynamic($where: funding_payments_bool_exp!) {
+    funding_payments_aggregate(where: $where) {
+      aggregate {
+        count
+        sum {
+          amount
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
- Add AssetFilter component with multi-select dropdown
- Refactor API layer to use dynamic filter objects instead of 40+ static query variants
- Add DataFilters interface with accountId, since, until, baseAssets
- Add dynamic GraphQL queries that accept where clause as variable
- Add getDistinctBaseAssets() API method to fetch available assets
- Update usePaginatedData hook with asset filter state and handler
- Add asset filter to all 4 pages (global trades/funding, account-specific trades/funding)
- Aggregates update based on selected asset filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)