### PR TITLE
Add account discovery flow for Drift and Hyperliquid

### DIFF
--- a/src/components/add-account-dialog.tsx
+++ b/src/components/add-account-dialog.tsx
@@ -6,11 +6,18 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
-import { Exchange, ExchangeAccountType } from "@/lib/queries";
+import {
+  discoverAccounts,
+  DiscoverableAccount,
+  getWalletInputPlaceholder,
+  getWalletInputHelp,
+} from "@/lib/api/exchanges";
+import { Exchange } from "@/lib/queries";
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Spinner } from "@/components/ui/spinner";
 import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -22,6 +29,7 @@ import {
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -35,41 +43,69 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-const accountSchema = z.object({
+// Step 1: Select exchange and enter wallet
+const walletSchema = z.object({
   exchange_id: z.string().min(1, "Exchange is required"),
-  account_identifier: z.string().min(1, "Account identifier is required"),
-  account_type: z.string().min(1, "Account type is required"),
+  wallet_address: z.string().min(1, "Wallet address is required"),
 });
 
-type AccountFormValues = z.infer<typeof accountSchema>;
+type WalletFormValues = z.infer<typeof walletSchema>;
 
 interface AddAccountDialogProps {
   onSuccess?: () => void;
 }
 
+type DialogStep = "wallet" | "select-accounts" | "adding";
+
 export function AddAccountDialog({ onSuccess }: AddAccountDialogProps) {
   const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<DialogStep>("wallet");
   const [exchanges, setExchanges] = useState<Exchange[]>([]);
-  const [accountTypes, setAccountTypes] = useState<ExchangeAccountType[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const [isLoadingExchanges, setIsLoadingExchanges] = useState(false);
-  const [isLoadingAccountTypes, setIsLoadingAccountTypes] = useState(false);
+  const [isDiscovering, setIsDiscovering] = useState(false);
+  const [isAddingAccounts, setIsAddingAccounts] = useState(false);
+  const [discoveredAccounts, setDiscoveredAccounts] = useState<
+    DiscoverableAccount[]
+  >([]);
+  const [selectedAccounts, setSelectedAccounts] = useState<Set<string>>(
+    new Set()
+  );
+  const [selectedExchange, setSelectedExchange] = useState<Exchange | null>(
+    null
+  );
 
-  const form = useForm<AccountFormValues>({
-    resolver: zodResolver(accountSchema),
+  const form = useForm<WalletFormValues>({
+    resolver: zodResolver(walletSchema),
     defaultValues: {
       exchange_id: "",
-      account_identifier: "",
-      account_type: "",
+      wallet_address: "",
     },
   });
+
+  const watchExchangeId = form.watch("exchange_id");
 
   useEffect(() => {
     if (open) {
       fetchExchanges();
-      fetchAccountTypes();
     }
   }, [open]);
+
+  // Update selected exchange when exchange_id changes
+  useEffect(() => {
+    const exchange = exchanges.find((e) => e.id === watchExchangeId);
+    setSelectedExchange(exchange || null);
+  }, [watchExchangeId, exchanges]);
+
+  // Reset state when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setStep("wallet");
+      setDiscoveredAccounts([]);
+      setSelectedAccounts(new Set());
+      setSelectedExchange(null);
+      form.reset();
+    }
+  }, [open, form]);
 
   const fetchExchanges = async () => {
     setIsLoadingExchanges(true);
@@ -84,169 +120,320 @@ export function AddAccountDialog({ onSuccess }: AddAccountDialogProps) {
     }
   };
 
-  const fetchAccountTypes = async () => {
-    setIsLoadingAccountTypes(true);
+  const handleDiscoverAccounts = async (data: WalletFormValues) => {
+    setIsDiscovering(true);
     try {
-      const data = await api.getAccountTypes();
-      setAccountTypes(data);
+      const exchange = exchanges.find((e) => e.id === data.exchange_id);
+      if (!exchange) {
+        throw new Error("Exchange not found");
+      }
+
+      const accounts = await discoverAccounts(
+        exchange.name,
+        data.wallet_address
+      );
+
+      if (accounts.length === 0) {
+        toast.error("No accounts found for this wallet address");
+        return;
+      }
+
+      setDiscoveredAccounts(accounts);
+      // Pre-select all accounts by default
+      setSelectedAccounts(new Set(accounts.map((a) => a.account_identifier)));
+      setStep("select-accounts");
     } catch (error) {
-      toast.error("Failed to fetch account types");
+      toast.error(
+        error instanceof Error ? error.message : "Failed to discover accounts"
+      );
       console.error(error);
     } finally {
-      setIsLoadingAccountTypes(false);
+      setIsDiscovering(false);
     }
   };
 
-  // Helper to format account type code for display
-  const formatAccountTypeLabel = (code: string): string => {
-    return code
-      .split("_")
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(" ");
+  const toggleAccountSelection = (accountIdentifier: string) => {
+    const newSelected = new Set(selectedAccounts);
+    if (newSelected.has(accountIdentifier)) {
+      newSelected.delete(accountIdentifier);
+    } else {
+      newSelected.add(accountIdentifier);
+    }
+    setSelectedAccounts(newSelected);
   };
 
-  function getErrorMessage(error: unknown): string {
-    if (error && typeof error === "object" && "response" in error) {
-      const response = error as {
-        response?: { errors?: { extensions?: { code?: string } }[] };
-      };
-      const code = response.response?.errors?.[0]?.extensions?.code;
+  const handleAddSelectedAccounts = async () => {
+    if (selectedAccounts.size === 0) {
+      toast.error("Please select at least one account");
+      return;
+    }
 
-      if (code === "constraint-violation") {
-        return "This account already exists for this exchange";
+    setStep("adding");
+    setIsAddingAccounts(true);
+
+    const accountsToAdd = discoveredAccounts.filter((a) =>
+      selectedAccounts.has(a.account_identifier)
+    );
+
+    let successCount = 0;
+    let errorCount = 0;
+
+    for (const account of accountsToAdd) {
+      try {
+        await api.createAccount({
+          exchange_id: form.getValues("exchange_id"),
+          account_identifier: account.account_identifier,
+          account_type: account.account_type,
+          account_type_metadata: account.metadata,
+        });
+        successCount++;
+      } catch (error) {
+        errorCount++;
+        console.error(
+          `Failed to add account ${account.account_identifier}:`,
+          error
+        );
       }
     }
-    return "Failed to add account";
-  }
 
-  async function onSubmit(data: AccountFormValues) {
-    setIsLoading(true);
-    try {
-      await api.createAccount({
-        exchange_id: data.exchange_id,
-        account_identifier: data.account_identifier,
-        account_type: data.account_type,
-        account_type_metadata: {},
-      });
-      toast.success("Account added successfully");
-      form.reset();
+    setIsAddingAccounts(false);
+
+    if (successCount > 0) {
+      toast.success(
+        `Successfully added ${successCount} account${successCount > 1 ? "s" : ""}`
+      );
       setOpen(false);
       onSuccess?.();
-    } catch (error) {
-      toast.error(getErrorMessage(error));
-      console.error(error);
-    } finally {
-      setIsLoading(false);
     }
-  }
+
+    if (errorCount > 0) {
+      toast.error(
+        `Failed to add ${errorCount} account${errorCount > 1 ? "s" : ""} (may already exist)`
+      );
+    }
+  };
+
+  const getAccountTypeBadgeVariant = (
+    type: string
+  ): "default" | "secondary" | "outline" => {
+    switch (type) {
+      case "main":
+        return "default";
+      case "sub_account":
+        return "secondary";
+      case "vault":
+        return "outline";
+      default:
+        return "default";
+    }
+  };
+
+  const formatAccountType = (type: string): string => {
+    switch (type) {
+      case "main":
+        return "Main";
+      case "sub_account":
+        return "Subaccount";
+      case "vault":
+        return "Vault";
+      default:
+        return type;
+    }
+  };
+
+  const truncateIdentifier = (id: string): string => {
+    if (id.length <= 16) return id;
+    return `${id.slice(0, 8)}...${id.slice(-6)}`;
+  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button>Add Account</Button>
       </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Add Exchange Account</DialogTitle>
-          <DialogDescription>
-            Connect a new exchange account to track your positions and trades.
-          </DialogDescription>
-        </DialogHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            <FormField
-              control={form.control}
-              name="exchange_id"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Exchange</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select an exchange" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {isLoadingExchanges ? (
-                        <div className="flex items-center justify-center py-2">
-                          <Spinner size="sm" />
-                        </div>
-                      ) : (
-                        exchanges.map((exchange) => (
-                          <SelectItem key={exchange.id} value={exchange.id}>
-                            {exchange.display_name}
-                          </SelectItem>
-                        ))
+      <DialogContent className="max-w-md">
+        {step === "wallet" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Add Exchange Account</DialogTitle>
+              <DialogDescription>
+                Enter your wallet address to discover accounts to sync.
+              </DialogDescription>
+            </DialogHeader>
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(handleDiscoverAccounts)}
+                className="space-y-4"
+              >
+                <FormField
+                  control={form.control}
+                  name="exchange_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Exchange</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select an exchange" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {isLoadingExchanges ? (
+                            <div className="flex items-center justify-center py-2">
+                              <Spinner size="sm" />
+                            </div>
+                          ) : (
+                            exchanges.map((exchange) => (
+                              <SelectItem key={exchange.id} value={exchange.id}>
+                                {exchange.display_name}
+                              </SelectItem>
+                            ))
+                          )}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="wallet_address"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Wallet Address</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder={
+                            selectedExchange
+                              ? getWalletInputPlaceholder(selectedExchange.name)
+                              : "Select an exchange first"
+                          }
+                          {...field}
+                        />
+                      </FormControl>
+                      {selectedExchange && (
+                        <FormDescription>
+                          {getWalletInputHelp(selectedExchange.name)}
+                        </FormDescription>
                       )}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="account_identifier"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Account Identifier</FormLabel>
-                  <FormControl>
-                    <Input placeholder="0x..." {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="account_type"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Account Type</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setOpen(false)}
                   >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select account type" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {isLoadingAccountTypes ? (
-                        <div className="flex items-center justify-center py-2">
-                          <Spinner size="sm" />
-                        </div>
-                      ) : (
-                        accountTypes.map((type) => (
-                          <SelectItem key={type.code} value={type.code}>
-                            {formatAccountTypeLabel(type.code)}
-                          </SelectItem>
-                        ))
-                      )}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <div className="flex justify-end gap-2">
+                    Cancel
+                  </Button>
+                  <LoadingButton type="submit" loading={isDiscovering}>
+                    Discover Accounts
+                  </LoadingButton>
+                </div>
+              </form>
+            </Form>
+          </>
+        )}
+
+        {step === "select-accounts" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Select Accounts to Sync</DialogTitle>
+              <DialogDescription>
+                {discoveredAccounts.length} account
+                {discoveredAccounts.length !== 1 ? "s" : ""} found. Select which
+                ones to add.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2 max-h-[300px] overflow-y-auto">
+              {discoveredAccounts.map((account) => (
+                <div
+                  key={account.account_identifier}
+                  className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                    selectedAccounts.has(account.account_identifier)
+                      ? "border-primary bg-primary/5"
+                      : "border-border hover:bg-muted/50"
+                  }`}
+                  onClick={() =>
+                    toggleAccountSelection(account.account_identifier)
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedAccounts.has(account.account_identifier)}
+                    onChange={() =>
+                      toggleAccountSelection(account.account_identifier)
+                    }
+                    className="h-4 w-4 rounded border-gray-300"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium truncate">
+                        {account.name}
+                      </span>
+                      <Badge
+                        variant={getAccountTypeBadgeVariant(
+                          account.account_type
+                        )}
+                      >
+                        {formatAccountType(account.account_type)}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground font-mono truncate">
+                      {truncateIdentifier(account.account_identifier)}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-between items-center pt-2">
               <Button
                 type="button"
-                variant="outline"
-                onClick={() => setOpen(false)}
+                variant="ghost"
+                size="sm"
+                onClick={() => setStep("wallet")}
               >
-                Cancel
+                Back
               </Button>
-              <LoadingButton type="submit" loading={isLoading}>
-                Add Account
-              </LoadingButton>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleAddSelectedAccounts}
+                  disabled={selectedAccounts.size === 0}
+                >
+                  Add {selectedAccounts.size} Account
+                  {selectedAccounts.size !== 1 ? "s" : ""}
+                </Button>
+              </div>
             </div>
-          </form>
-        </Form>
+          </>
+        )}
+
+        {step === "adding" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Adding Accounts</DialogTitle>
+              <DialogDescription>
+                Please wait while we add your selected accounts...
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center justify-center py-8">
+              <Spinner size="lg" />
+            </div>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/lib/api/exchanges.ts
+++ b/src/lib/api/exchanges.ts
@@ -1,0 +1,73 @@
+// Exchange API client for account discovery via backend service
+
+export interface DiscoverableAccount {
+  account_identifier: string;
+  account_type: "main" | "sub_account" | "vault";
+  name: string;
+  metadata: Record<string, unknown>;
+}
+
+interface DiscoverResponse {
+  success: boolean;
+  accounts: DiscoverableAccount[];
+  error?: string;
+}
+
+// Discovery service URL - uses environment variable or defaults to localhost
+const DISCOVERY_SERVICE_URL =
+  process.env.NEXT_PUBLIC_DISCOVERY_URL || "http://localhost:8082";
+
+/**
+ * Discover accounts for any supported exchange via backend service
+ */
+export async function discoverAccounts(
+  exchangeName: string,
+  userIdentifier: string
+): Promise<DiscoverableAccount[]> {
+  const url = new URL("/discover", DISCOVERY_SERVICE_URL);
+  url.searchParams.set("exchange", exchangeName);
+  url.searchParams.set("wallet", userIdentifier);
+
+  const response = await fetch(url.toString());
+
+  if (!response.ok) {
+    const data: DiscoverResponse = await response.json();
+    throw new Error(data.error || `Discovery failed with status ${response.status}`);
+  }
+
+  const data: DiscoverResponse = await response.json();
+
+  if (!data.success) {
+    throw new Error(data.error || "Discovery failed");
+  }
+
+  return data.accounts;
+}
+
+/**
+ * Get placeholder text for the wallet input based on exchange
+ */
+export function getWalletInputPlaceholder(exchangeName: string): string {
+  switch (exchangeName.toLowerCase()) {
+    case "hyperliquid":
+      return "0x... (Ethereum wallet address)";
+    case "drift":
+      return "Solana wallet address";
+    default:
+      return "Wallet address";
+  }
+}
+
+/**
+ * Get help text for the wallet input based on exchange
+ */
+export function getWalletInputHelp(exchangeName: string): string {
+  switch (exchangeName.toLowerCase()) {
+    case "hyperliquid":
+      return "Enter your Ethereum wallet address to discover your main account, subaccounts, and vaults.";
+    case "drift":
+      return "Enter your Solana wallet address (authority) to discover your Drift subaccounts.";
+    default:
+      return "Enter your wallet address to discover accounts.";
+  }
+}


### PR DESCRIPTION
- Add exchanges.ts API client for direct exchange discovery calls
- Update add-account-dialog with multi-step discovery flow:
  1. Enter wallet address
  2. Discover subaccounts/vaults
  3. Select accounts to add
- Support both Drift (Solana) and Hyperliquid (EVM) address formats