### PR TITLE
Add Lighter.xyz exchange support to account discovery UI

### DIFF
--- a/src/components/add-account-dialog.tsx
+++ b/src/components/add-account-dialog.tsx
@@ -11,6 +11,10 @@ import {
   DiscoverableAccount,
   getWalletInputPlaceholder,
   getWalletInputHelp,
+  exchangeRequiresAuthToken,
+  getAuthTokenPlaceholder,
+  getAuthTokenHelp,
+  buildUserIdentifier,
 } from "@/lib/api/exchanges";
 import { Exchange } from "@/lib/queries";
 import { Button } from "@/components/ui/button";
@@ -47,6 +51,7 @@ import {
 const walletSchema = z.object({
   exchange_id: z.string().min(1, "Exchange is required"),
   wallet_address: z.string().min(1, "Wallet address is required"),
+  auth_token: z.string().optional(),
 });
 
 type WalletFormValues = z.infer<typeof walletSchema>;
@@ -79,6 +84,7 @@ export function AddAccountDialog({ onSuccess }: AddAccountDialogProps) {
     defaultValues: {
       exchange_id: "",
       wallet_address: "",
+      auth_token: "",
     },
   });
 
@@ -128,10 +134,19 @@ export function AddAccountDialog({ onSuccess }: AddAccountDialogProps) {
         throw new Error("Exchange not found");
       }
 
-      const accounts = await discoverAccounts(
+      // Validate auth token for exchanges that require it
+      if (exchangeRequiresAuthToken(exchange.name) && !data.auth_token) {
+        throw new Error("Auth token is required for this exchange");
+      }
+
+      // Build the user identifier based on exchange requirements
+      const userIdentifier = buildUserIdentifier(
         exchange.name,
-        data.wallet_address
+        data.wallet_address,
+        data.auth_token
       );
+
+      const accounts = await discoverAccounts(exchange.name, userIdentifier);
 
       if (accounts.length === 0) {
         toast.error("No accounts found for this wallet address");
@@ -323,6 +338,30 @@ export function AddAccountDialog({ onSuccess }: AddAccountDialogProps) {
                     </FormItem>
                   )}
                 />
+                {selectedExchange &&
+                  exchangeRequiresAuthToken(selectedExchange.name) && (
+                    <FormField
+                      control={form.control}
+                      name="auth_token"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Auth Token</FormLabel>
+                          <FormControl>
+                            <Input
+                              placeholder={getAuthTokenPlaceholder(
+                                selectedExchange.name
+                              )}
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormDescription>
+                            {getAuthTokenHelp(selectedExchange.name)}
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
                 <div className="flex justify-end gap-2">
                   <Button
                     type="button"

--- a/src/lib/api/exchanges.ts
+++ b/src/lib/api/exchanges.ts
@@ -53,6 +53,8 @@ export function getWalletInputPlaceholder(exchangeName: string): string {
       return "0x... (Ethereum wallet address)";
     case "drift":
       return "Solana wallet address";
+    case "lighter":
+      return "0x... (L1 wallet address)";
     default:
       return "Wallet address";
   }
@@ -67,7 +69,61 @@ export function getWalletInputHelp(exchangeName: string): string {
       return "Enter your Ethereum wallet address to discover your main account, subaccounts, and vaults.";
     case "drift":
       return "Enter your Solana wallet address (authority) to discover your Drift subaccounts.";
+    case "lighter":
+      return "Enter your L1 wallet address and read-only auth token to discover your Lighter accounts.";
     default:
       return "Enter your wallet address to discover accounts.";
+  }
+}
+
+/**
+ * Check if an exchange requires an auth token for discovery
+ */
+export function exchangeRequiresAuthToken(exchangeName: string): boolean {
+  return exchangeName.toLowerCase() === "lighter";
+}
+
+/**
+ * Get placeholder text for the auth token input
+ */
+export function getAuthTokenPlaceholder(exchangeName: string): string {
+  switch (exchangeName.toLowerCase()) {
+    case "lighter":
+      return "ro:account_index:all:expiry:hex...";
+    default:
+      return "Auth token";
+  }
+}
+
+/**
+ * Get help text for the auth token input
+ */
+export function getAuthTokenHelp(exchangeName: string): string {
+  switch (exchangeName.toLowerCase()) {
+    case "lighter":
+      return "Generate a read-only auth token from Lighter.xyz. Format: ro:{account_index}:{single|all}:{expiry_unix}:{random_hex}";
+    default:
+      return "Enter your authentication token.";
+  }
+}
+
+/**
+ * Build the user identifier for discovery based on exchange requirements
+ * For most exchanges, this is just the wallet address
+ * For Lighter, this combines the L1 address and auth token
+ */
+export function buildUserIdentifier(
+  exchangeName: string,
+  walletAddress: string,
+  authToken?: string
+): string {
+  switch (exchangeName.toLowerCase()) {
+    case "lighter":
+      if (!authToken) {
+        throw new Error("Auth token is required for Lighter");
+      }
+      return `${walletAddress}:${authToken}`;
+    default:
+      return walletAddress;
   }
 }


### PR DESCRIPTION
- Add auth token input field for exchanges that require it
- Add Lighter-specific placeholder and help text
- Build combined user identifier (l1_address:auth_token) for Lighter discovery
- Validate auth token is provided when required