### PR TITLE
feat: add tags feature for accounts and wallets

### DIFF
--- a/src/app/(dashboard)/funding/page.tsx
+++ b/src/app/(dashboard)/funding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import { TagFilter } from "@/components/tag-filter";
 import { api, DataFilters } from "@/lib/api";
 import { FundingPayment, ExchangeAccount, FundingAggregates } from "@/lib/queries";
 import { FundingTable } from "@/components/funding-table";
@@ -43,11 +44,13 @@ export default function FundingPage() {
     selectedAccountId,
     dateRange,
     selectedAssets,
+    selectedTags,
     isNew,
     handlePageChange,
     handleAccountChange,
     handleDateRangeChange,
     handleAssetChange,
+    handleTagChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<FundingPayment, FundingAggregates>({
@@ -82,6 +85,15 @@ export default function FundingPage() {
     };
     fetchAssets();
   }, []);
+
+  // Get all unique tags from accounts
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    accounts.forEach((account) => {
+      (account.tags || []).forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort();
+  }, [accounts]);
 
   const totalAmount = aggregates ? parseFloat(aggregates.totalAmount) : 0;
   const isPositive = totalAmount >= 0;
@@ -122,6 +134,11 @@ export default function FundingPage() {
             {selectedAccountId === "all" ? "All Funding Payments" : "Filtered Payments"}
           </CardTitle>
           <div className="flex items-center gap-4">
+            <TagFilter
+              availableTags={availableTags}
+              selectedTags={selectedTags}
+              onSelectionChange={handleTagChange}
+            />
             <AssetFilter
               assets={availableAssets}
               selectedAssets={selectedAssets}

--- a/src/app/(dashboard)/positions/page.tsx
+++ b/src/app/(dashboard)/positions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { api, DataFilters } from "@/lib/api";
 import { Position, ExchangeAccount, PositionsAggregates } from "@/lib/queries";
 import { PositionsTable } from "@/components/positions-table";
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { DateRangeFilter } from "@/components/date-range-filter";
 import { AssetFilter } from "@/components/asset-filter";
+import { TagFilter } from "@/components/tag-filter";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
@@ -48,11 +49,13 @@ export default function PositionsPage() {
     selectedAccountId,
     dateRange,
     selectedAssets,
+    selectedTags,
     isNew,
     handlePageChange,
     handleAccountChange,
     handleDateRangeChange,
     handleAssetChange,
+    handleTagChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<Position, PositionsAggregates>({
@@ -87,6 +90,15 @@ export default function PositionsPage() {
     };
     fetchAssets();
   }, []);
+
+  // Get all unique tags from accounts
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    accounts.forEach((account) => {
+      (account.tags || []).forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort();
+  }, [accounts]);
 
   const formatPnL = (value: string) => {
     const num = parseFloat(value);
@@ -143,6 +155,11 @@ export default function PositionsPage() {
             {selectedAccountId === "all" ? "All Positions" : "Filtered Positions"}
           </CardTitle>
           <div className="flex items-center gap-4">
+            <TagFilter
+              availableTags={availableTags}
+              selectedTags={selectedTags}
+              onSelectionChange={handleTagChange}
+            />
             <AssetFilter
               assets={availableAssets}
               selectedAssets={selectedAssets}

--- a/src/app/(dashboard)/trades/page.tsx
+++ b/src/app/(dashboard)/trades/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { api, DataFilters } from "@/lib/api";
 import { Trade, ExchangeAccount, TradesAggregates } from "@/lib/queries";
 import { TradesTable } from "@/components/trades-table";
@@ -17,6 +17,7 @@ import {
 import { DateRangeFilter } from "@/components/date-range-filter";
 import { AssetFilter } from "@/components/asset-filter";
 import { MarketTypeFilter } from "@/components/market-type-filter";
+import { TagFilter } from "@/components/tag-filter";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
@@ -50,12 +51,14 @@ export default function TradesPage() {
     dateRange,
     selectedAssets,
     selectedMarketTypes,
+    selectedTags,
     isNew,
     handlePageChange,
     handleAccountChange,
     handleDateRangeChange,
     handleAssetChange,
     handleMarketTypeChange,
+    handleTagChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<Trade, TradesAggregates>({
@@ -90,6 +93,15 @@ export default function TradesPage() {
     };
     fetchAssets();
   }, []);
+
+  // Get all unique tags from accounts
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    accounts.forEach((account) => {
+      (account.tags || []).forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort();
+  }, [accounts]);
 
   const formatFees = (value: string) => {
     const num = parseFloat(value);
@@ -132,6 +144,11 @@ export default function TradesPage() {
             {selectedAccountId === "all" ? "All Trades" : "Filtered Trades"}
           </CardTitle>
           <div className="flex items-center gap-4">
+            <TagFilter
+              availableTags={availableTags}
+              selectedTags={selectedTags}
+              onSelectionChange={handleTagChange}
+            />
             <MarketTypeFilter
               value={selectedMarketTypes}
               onChange={handleMarketTypeChange}

--- a/src/components/accounts-table.tsx
+++ b/src/components/accounts-table.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { ExchangeAccount } from "@/lib/queries";
 import { useApi } from "@/hooks/use-api";
@@ -16,6 +17,8 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { AccountsTableSkeleton } from "@/components/table-skeleton";
+import { TagInput } from "@/components/tag-input";
+import { TagFilter } from "@/components/tag-filter";
 
 interface AccountsTableProps {
   refreshKey?: number;
@@ -58,6 +61,7 @@ export function AccountsTable({ refreshKey, onLoadingChange, onRefreshComplete }
   const { withErrorReporting } = useApi();
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
   const fetchAccounts = async () => {
     setIsLoading(true);
@@ -78,11 +82,28 @@ export function AccountsTable({ refreshKey, onLoadingChange, onRefreshComplete }
     fetchAccounts();
   }, [refreshKey]);
 
+  // Get all unique tags from accounts
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    accounts.forEach((account) => {
+      (account.tags || []).forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort();
+  }, [accounts]);
+
+  // Filter accounts by selected tags
+  const filteredAccounts = useMemo(() => {
+    if (selectedTags.length === 0) return accounts;
+    return accounts.filter((account) =>
+      selectedTags.some((tag) => (account.tags || []).includes(tag))
+    );
+  }, [accounts, selectedTags]);
+
   // Group accounts by wallet address
   const walletGroups = useMemo((): WalletGroup[] => {
     const groups = new Map<string | null, ExchangeAccount[]>();
 
-    for (const account of accounts) {
+    for (const account of filteredAccounts) {
       const key = account.wallet?.address || null;
       const existing = groups.get(key) || [];
       existing.push(account);
@@ -97,12 +118,23 @@ export function AccountsTable({ refreshKey, onLoadingChange, onRefreshComplete }
         return a.localeCompare(b);
       })
       .map(([walletAddress, accts]) => ({ walletAddress, accounts: accts }));
-  }, [accounts]);
+  }, [filteredAccounts]);
 
   // Check if we should show wallet grouping (at least one account has a wallet)
   const hasWalletGrouping = useMemo(() => {
-    return accounts.some(a => a.wallet?.address);
-  }, [accounts]);
+    return filteredAccounts.some(a => a.wallet?.address);
+  }, [filteredAccounts]);
+
+  const handleTagsChange = async (accountId: string, newTags: string[]) => {
+    try {
+      await api.updateAccountTags(accountId, newTags);
+      setAccounts((prev) =>
+        prev.map((a) => (a.id === accountId ? { ...a, tags: newTags } : a))
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update tags");
+    }
+  };
 
   if (isLoading) {
     return <AccountsTableSkeleton rows={3} />;
@@ -122,101 +154,139 @@ export function AccountsTable({ refreshKey, onLoadingChange, onRefreshComplete }
   // If no wallet grouping, show simple table
   if (!hasWalletGrouping) {
     return (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Exchange</TableHead>
-            <TableHead>Account Identifier</TableHead>
-            <TableHead>Type</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {accounts.map((account) => (
-            <TableRow
-              key={account.id}
-              className="cursor-pointer"
-              onClick={() => router.push(`/accounts/${account.id}`)}
-            >
-              <TableCell className="font-medium">
-                {account.exchange?.display_name || "Unknown"}
-              </TableCell>
-              <TableCell className="font-mono text-sm">
-                {truncateAddress(account.account_identifier, 10, 8)}
-              </TableCell>
-              <TableCell>
-                <Badge variant="secondary">{account.account_type}</Badge>
-              </TableCell>
+      <div className="space-y-4">
+        {availableTags.length > 0 && (
+          <div className="flex justify-end">
+            <TagFilter
+              availableTags={availableTags}
+              selectedTags={selectedTags}
+              onSelectionChange={setSelectedTags}
+            />
+          </div>
+        )}
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Exchange</TableHead>
+              <TableHead>Account Identifier</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Tags</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {filteredAccounts.map((account) => (
+              <TableRow
+                key={account.id}
+                className="cursor-pointer"
+                onClick={() => router.push(`/accounts/${account.id}`)}
+              >
+                <TableCell className="font-medium">
+                  {account.exchange?.display_name || "Unknown"}
+                </TableCell>
+                <TableCell className="font-mono text-sm">
+                  {truncateAddress(account.account_identifier, 10, 8)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="secondary">{account.account_type}</Badge>
+                </TableCell>
+                <TableCell>
+                  <TagInput
+                    tags={account.tags || []}
+                    onTagsChange={(tags) => handleTagsChange(account.id, tags)}
+                    availableTags={availableTags}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     );
   }
 
   // Show grouped table with wallet headers
   return (
-    <div className="space-y-6">
-      {walletGroups.map((group) => (
-        <div key={group.walletAddress || "ungrouped"} className="space-y-2">
-          {group.walletAddress && (
-            <div className="flex items-center gap-2 px-2">
-              <span className="text-sm font-medium text-muted-foreground">Wallet:</span>
-              <code className="text-sm font-mono bg-muted px-2 py-0.5 rounded">
-                {truncateAddress(group.walletAddress, 8, 6)}
-              </code>
-              <Badge variant="outline" className="text-xs">
-                {group.accounts.length} account{group.accounts.length !== 1 ? "s" : ""}
-              </Badge>
-            </div>
-          )}
-          {!group.walletAddress && walletGroups.length > 1 && (
-            <div className="flex items-center gap-2 px-2">
-              <span className="text-sm font-medium text-muted-foreground">Other Accounts</span>
-              <Badge variant="outline" className="text-xs">
-                {group.accounts.length} account{group.accounts.length !== 1 ? "s" : ""}
-              </Badge>
-            </div>
-          )}
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Protocol</TableHead>
-                <TableHead>Account Identifier</TableHead>
-                <TableHead>Type</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Last Synced</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {group.accounts.map((account) => (
-                <TableRow
-                  key={account.id}
-                  className="cursor-pointer"
-                  onClick={() => router.push(`/accounts/${account.id}`)}
-                >
-                  <TableCell>
-                    <Badge variant="secondary">
-                      {account.exchange?.display_name || "Unknown"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="font-mono text-sm">
-                    {truncateAddress(account.account_identifier, 10, 8)}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="outline">{account.account_type}</Badge>
-                  </TableCell>
-                  <TableCell>
-                    {getStatusBadge(account.status)}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-sm">
-                    {formatRelativeTime(account.last_synced_at)}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+    <div className="space-y-4">
+      {availableTags.length > 0 && (
+        <div className="flex justify-end">
+          <TagFilter
+            availableTags={availableTags}
+            selectedTags={selectedTags}
+            onSelectionChange={setSelectedTags}
+          />
         </div>
-      ))}
+      )}
+      <div className="space-y-6">
+        {walletGroups.map((group) => (
+          <div key={group.walletAddress || "ungrouped"} className="space-y-2">
+            {group.walletAddress && (
+              <div className="flex items-center gap-2 px-2">
+                <span className="text-sm font-medium text-muted-foreground">Wallet:</span>
+                <code className="text-sm font-mono bg-muted px-2 py-0.5 rounded">
+                  {truncateAddress(group.walletAddress, 8, 6)}
+                </code>
+                <Badge variant="outline" className="text-xs">
+                  {group.accounts.length} account{group.accounts.length !== 1 ? "s" : ""}
+                </Badge>
+              </div>
+            )}
+            {!group.walletAddress && walletGroups.length > 1 && (
+              <div className="flex items-center gap-2 px-2">
+                <span className="text-sm font-medium text-muted-foreground">Other Accounts</span>
+                <Badge variant="outline" className="text-xs">
+                  {group.accounts.length} account{group.accounts.length !== 1 ? "s" : ""}
+                </Badge>
+              </div>
+            )}
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Protocol</TableHead>
+                  <TableHead>Account Identifier</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Tags</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Synced</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {group.accounts.map((account) => (
+                  <TableRow
+                    key={account.id}
+                    className="cursor-pointer"
+                    onClick={() => router.push(`/accounts/${account.id}`)}
+                  >
+                    <TableCell>
+                      <Badge variant="secondary">
+                        {account.exchange?.display_name || "Unknown"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-mono text-sm">
+                      {truncateAddress(account.account_identifier, 10, 8)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{account.account_type}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      <TagInput
+                        tags={account.tags || []}
+                        onTagsChange={(tags) => handleTagsChange(account.id, tags)}
+                        availableTags={availableTags}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {getStatusBadge(account.status)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatRelativeTime(account.last_synced_at)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/tag-badge.tsx
+++ b/src/components/tag-badge.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface TagBadgeProps {
+  tag: string;
+  onRemove?: () => void;
+  className?: string;
+}
+
+export function TagBadge({ tag, onRemove, className }: TagBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-foreground",
+        className
+      )}
+    >
+      {tag}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="ml-0.5 rounded-full p-0.5 hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <X className="h-3 w-3" />
+          <span className="sr-only">Remove {tag}</span>
+        </button>
+      )}
+    </span>
+  );
+}

--- a/src/components/tag-filter.tsx
+++ b/src/components/tag-filter.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface TagFilterProps {
+  availableTags: string[];
+  selectedTags: string[];
+  onSelectionChange: (tags: string[]) => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export function TagFilter({
+  availableTags,
+  selectedTags,
+  onSelectionChange,
+  isLoading = false,
+  className,
+}: TagFilterProps) {
+  const handleTagToggle = (tag: string) => {
+    if (selectedTags.includes(tag)) {
+      onSelectionChange(selectedTags.filter((t) => t !== tag));
+    } else {
+      onSelectionChange([...selectedTags, tag]);
+    }
+  };
+
+  const handleSelectAll = () => {
+    onSelectionChange([]);
+  };
+
+  const getButtonLabel = () => {
+    if (selectedTags.length === 0) {
+      return "All Tags";
+    }
+    if (selectedTags.length === 1) {
+      return selectedTags[0];
+    }
+    return `${selectedTags.length} tags`;
+  };
+
+  if (availableTags.length === 0 && !isLoading) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant={selectedTags.length > 0 ? "default" : "outline"}
+          size="sm"
+          className={cn("h-[34px] min-w-[100px] justify-between", className)}
+          disabled={isLoading}
+        >
+          <span>{isLoading ? "Loading..." : getButtonLabel()}</span>
+          <ChevronDown className="ml-2 h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[160px]">
+        <DropdownMenuLabel>Filter by Tag</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem
+          checked={selectedTags.length === 0}
+          onCheckedChange={handleSelectAll}
+        >
+          All Tags
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        {availableTags.map((tag) => (
+          <DropdownMenuCheckboxItem
+            key={tag}
+            checked={selectedTags.includes(tag)}
+            onCheckedChange={() => handleTagToggle(tag)}
+          >
+            {tag}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useRef, useEffect, KeyboardEvent } from "react";
+import { Plus } from "lucide-react";
+import { TagBadge } from "./tag-badge";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface TagInputProps {
+  tags: string[];
+  onTagsChange: (tags: string[]) => void;
+  availableTags?: string[];
+  maxTags?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function TagInput({
+  tags,
+  onTagsChange,
+  availableTags = [],
+  maxTags = 5,
+  disabled = false,
+  className,
+}: TagInputProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const normalizedTags = tags.map((t) => t.toLowerCase());
+
+  const filteredSuggestions = availableTags.filter(
+    (tag) =>
+      !normalizedTags.includes(tag.toLowerCase()) &&
+      tag.toLowerCase().includes(inputValue.toLowerCase())
+  );
+
+  const handleAddTag = (tag: string) => {
+    const trimmedTag = tag.trim().toLowerCase();
+    if (
+      trimmedTag &&
+      !normalizedTags.includes(trimmedTag) &&
+      tags.length < maxTags
+    ) {
+      onTagsChange([...tags, trimmedTag]);
+      setInputValue("");
+      setIsOpen(false);
+    }
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    onTagsChange(tags.filter((t) => t !== tagToRemove));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddTag(inputValue);
+    } else if (e.key === "Escape") {
+      setIsOpen(false);
+      setInputValue("");
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isOpen]);
+
+  return (
+    <div
+      className={cn("flex flex-wrap items-center gap-1", className)}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {tags.map((tag) => (
+        <TagBadge
+          key={tag}
+          tag={tag}
+          onRemove={disabled ? undefined : () => handleRemoveTag(tag)}
+        />
+      ))}
+      {!disabled && tags.length < maxTags && (
+        <Popover open={isOpen} onOpenChange={setIsOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <Plus className="mr-1 h-3 w-3" />
+              Add tag
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-48 p-2" align="start">
+            <Input
+              ref={inputRef}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Enter tag..."
+              className="h-8 text-sm"
+            />
+            {filteredSuggestions.length > 0 && (
+              <div className="mt-2 max-h-32 overflow-y-auto">
+                {filteredSuggestions.slice(0, 5).map((suggestion) => (
+                  <button
+                    key={suggestion}
+                    type="button"
+                    onClick={() => handleAddTag(suggestion)}
+                    className="w-full rounded px-2 py-1 text-left text-sm hover:bg-accent"
+                  >
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            )}
+            {inputValue && !filteredSuggestions.includes(inputValue.toLowerCase()) && (
+              <div className="mt-2 text-xs text-muted-foreground">
+                Press Enter to add &quot;{inputValue}&quot;
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/src/components/wallets-section.tsx
+++ b/src/components/wallets-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { WalletWithAccounts } from "@/lib/queries";
@@ -29,6 +29,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Loader2, Trash2 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TagInput } from "@/components/tag-input";
+import { TagFilter } from "@/components/tag-filter";
 
 interface WalletsSectionProps {
   refreshKey?: number;
@@ -61,6 +63,7 @@ function WalletsSkeleton() {
           <Skeleton className="h-4 w-16" />
           <Skeleton className="h-4 w-20" />
           <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-20" />
           <Skeleton className="h-4 w-8" />
         </div>
       ))}
@@ -73,6 +76,7 @@ export function WalletsSection({ refreshKey, detectingWalletId, onWalletDeleted 
   const [wallets, setWallets] = useState<WalletWithAccounts[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
   const pollCountRef = useRef(0);
 
@@ -125,6 +129,23 @@ export function WalletsSection({ refreshKey, detectingWalletId, onWalletDeleted 
     }
   }, [detectingWalletId, fetchWallets]);
 
+  // Get all unique tags from wallets
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    wallets.forEach((wallet) => {
+      (wallet.tags || []).forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort();
+  }, [wallets]);
+
+  // Filter wallets by selected tags
+  const filteredWallets = useMemo(() => {
+    if (selectedTags.length === 0) return wallets;
+    return wallets.filter((wallet) =>
+      selectedTags.some((tag) => (wallet.tags || []).includes(tag))
+    );
+  }, [wallets, selectedTags]);
+
   const handleDelete = async (walletId: string) => {
     setDeletingId(walletId);
     try {
@@ -136,6 +157,17 @@ export function WalletsSection({ refreshKey, detectingWalletId, onWalletDeleted 
       toast.error(error instanceof Error ? error.message : "Failed to delete wallet");
     } finally {
       setDeletingId(null);
+    }
+  };
+
+  const handleTagsChange = async (walletId: string, newTags: string[]) => {
+    try {
+      await api.updateWalletTags(walletId, newTags);
+      setWallets((prev) =>
+        prev.map((w) => (w.id === walletId ? { ...w, tags: newTags } : w))
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update tags");
     }
   };
 
@@ -152,93 +184,112 @@ export function WalletsSection({ refreshKey, detectingWalletId, onWalletDeleted 
   }
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Address</TableHead>
-          <TableHead>Chain</TableHead>
-          <TableHead>Added</TableHead>
-          <TableHead>Last Detected</TableHead>
-          <TableHead className="text-center">Accounts</TableHead>
-          <TableHead className="w-[50px]"></TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {wallets.map((wallet) => {
-          const isDetecting = detectingWalletId === wallet.id && !wallet.last_detected_at;
-          const accountCount = wallet.exchange_accounts_aggregate?.aggregate?.count ?? 0;
+    <div className="space-y-4">
+      {availableTags.length > 0 && (
+        <div className="flex justify-end">
+          <TagFilter
+            availableTags={availableTags}
+            selectedTags={selectedTags}
+            onSelectionChange={setSelectedTags}
+          />
+        </div>
+      )}
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Address</TableHead>
+            <TableHead>Chain</TableHead>
+            <TableHead>Tags</TableHead>
+            <TableHead>Added</TableHead>
+            <TableHead>Last Detected</TableHead>
+            <TableHead className="text-center">Accounts</TableHead>
+            <TableHead className="w-[50px]"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filteredWallets.map((wallet) => {
+            const isDetecting = detectingWalletId === wallet.id && !wallet.last_detected_at;
+            const accountCount = wallet.exchange_accounts_aggregate?.aggregate?.count ?? 0;
 
-          return (
-            <TableRow key={wallet.id}>
-              <TableCell className="font-mono text-sm">
-                {truncateAddress(wallet.address, 8, 6)}
-              </TableCell>
-              <TableCell>
-                <Badge variant={getChainBadgeVariant(wallet.chain)}>
-                  {wallet.chain.charAt(0).toUpperCase() + wallet.chain.slice(1)}
-                </Badge>
-              </TableCell>
-              <TableCell className="text-muted-foreground text-sm">
-                {formatRelativeTime(wallet.created_at)}
-              </TableCell>
-              <TableCell className="text-sm">
-                {isDetecting ? (
-                  <span className="flex items-center gap-2 text-muted-foreground">
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                    Detecting...
-                  </span>
-                ) : (
-                  <span className="text-muted-foreground">
-                    {formatRelativeTime(wallet.last_detected_at)}
-                  </span>
-                )}
-              </TableCell>
-              <TableCell className="text-center">
-                {isDetecting ? (
-                  <span className="text-muted-foreground">-</span>
-                ) : (
-                  <Badge variant="outline">{accountCount}</Badge>
-                )}
-              </TableCell>
-              <TableCell>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                      disabled={deletingId === wallet.id}
-                    >
-                      {deletingId === wallet.id ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Trash2 className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Delete Wallet</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        Are you sure you want to delete this wallet? This will also delete all associated accounts and their data.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={() => handleDelete(wallet.id)}
-                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            return (
+              <TableRow key={wallet.id}>
+                <TableCell className="font-mono text-sm">
+                  {truncateAddress(wallet.address, 8, 6)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={getChainBadgeVariant(wallet.chain)}>
+                    {wallet.chain.charAt(0).toUpperCase() + wallet.chain.slice(1)}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <TagInput
+                    tags={wallet.tags || []}
+                    onTagsChange={(tags) => handleTagsChange(wallet.id, tags)}
+                    availableTags={availableTags}
+                  />
+                </TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {formatRelativeTime(wallet.created_at)}
+                </TableCell>
+                <TableCell className="text-sm">
+                  {isDetecting ? (
+                    <span className="flex items-center gap-2 text-muted-foreground">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      Detecting...
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">
+                      {formatRelativeTime(wallet.last_detected_at)}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="text-center">
+                  {isDetecting ? (
+                    <span className="text-muted-foreground">-</span>
+                  ) : (
+                    <Badge variant="outline">{accountCount}</Badge>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                        disabled={deletingId === wallet.id}
                       >
-                        Delete
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </TableCell>
-            </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
+                        {deletingId === wallet.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Wallet</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Are you sure you want to delete this wallet? This will also delete all associated accounts and their data.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => handleDelete(wallet.id)}
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                          Delete
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
   );
 }

--- a/src/hooks/use-paginated-data.ts
+++ b/src/hooks/use-paginated-data.ts
@@ -52,6 +52,7 @@ export interface UsePaginatedDataResult<TItem, TAggregates> {
   dateRange: DateRangeValue;
   selectedAssets: string[];
   selectedMarketTypes: ("perp" | "spot")[];
+  selectedTags: string[];
 
   // New item tracking
   isNew: (id: string) => boolean;
@@ -62,6 +63,7 @@ export interface UsePaginatedDataResult<TItem, TAggregates> {
   handleDateRangeChange: (newRange: DateRangeValue) => void;
   handleAssetChange: (assets: string[]) => void;
   handleMarketTypeChange: (marketTypes: ("perp" | "spot")[]) => void;
+  handleTagChange: (tags: string[]) => void;
 
   // Refresh
   refresh: () => void;
@@ -99,6 +101,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
   const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
   const [selectedMarketTypes, setSelectedMarketTypes] = useState<("perp" | "spot")[]>([]);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
   // New item tracking
   const { updateItems: updateNewItems, isNew } = useNewItems<TItem>();
@@ -109,6 +112,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   const dateRangeRef = useRef(dateRange);
   const selectedAssetsRef = useRef(selectedAssets);
   const selectedMarketTypesRef = useRef(selectedMarketTypes);
+  const selectedTagsRef = useRef(selectedTags);
 
   useEffect(() => {
     pageRef.current = page;
@@ -116,11 +120,12 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
     dateRangeRef.current = dateRange;
     selectedAssetsRef.current = selectedAssets;
     selectedMarketTypesRef.current = selectedMarketTypes;
-  }, [page, selectedAccountId, dateRange, selectedAssets, selectedMarketTypes]);
+    selectedTagsRef.current = selectedTags;
+  }, [page, selectedAccountId, dateRange, selectedAssets, selectedMarketTypes, selectedTags]);
 
   // Build filters object from current state
   const buildFilters = useCallback(
-    (accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[]): DataFilters => {
+    (accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[], tags: string[]): DataFilters => {
       const { since, until } = getTimestampsFromDateRange(dateRangeValue);
       return {
         accountId: accId === "all" ? undefined : accId,
@@ -128,6 +133,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
         until,
         baseAssets: assets.length > 0 ? assets : undefined,
         marketTypes: marketTypes.length > 0 ? marketTypes : undefined,
+        tags: tags.length > 0 ? tags : undefined,
       };
     },
     []
@@ -135,9 +141,9 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
 
   // Fetch aggregates
   const doFetchAggregates = useCallback(
-    async (accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[]) => {
+    async (accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[], tags: string[]) => {
       setIsLoadingAggregates(true);
-      const filters = buildFilters(accId, dateRangeValue, assets, marketTypes);
+      const filters = buildFilters(accId, dateRangeValue, assets, marketTypes, tags);
 
       try {
         const data = await withErrorReporting(() => fetchAggregates(filters));
@@ -153,9 +159,9 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
 
   // Fetch items
   const doFetchItems = useCallback(
-    async (pageNum: number, accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[]) => {
+    async (pageNum: number, accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[], tags: string[]) => {
       setIsLoading(true);
-      const filters = buildFilters(accId, dateRangeValue, assets, marketTypes);
+      const filters = buildFilters(accId, dateRangeValue, assets, marketTypes, tags);
 
       try {
         const data = await withErrorReporting(() =>
@@ -181,13 +187,15 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
         selectedAccountIdRef.current,
         dateRangeRef.current,
         selectedAssetsRef.current,
-        selectedMarketTypesRef.current
+        selectedMarketTypesRef.current,
+        selectedTagsRef.current
       ),
       doFetchAggregates(
         selectedAccountIdRef.current,
         dateRangeRef.current,
         selectedAssetsRef.current,
-        selectedMarketTypesRef.current
+        selectedMarketTypesRef.current,
+        selectedTagsRef.current
       ),
     ]);
   }, [doFetchItems, doFetchAggregates]);
@@ -205,7 +213,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   // Refetch when filters change
   useEffect(() => {
     refresh();
-  }, [page, selectedAccountId, dateRange, selectedAssets, selectedMarketTypes]);
+  }, [page, selectedAccountId, dateRange, selectedAssets, selectedMarketTypes, selectedTags]);
 
   // If accountId prop changes (for account-specific pages), update filter
   useEffect(() => {
@@ -239,6 +247,11 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
     setPage(0);
   }, []);
 
+  const handleTagChange = useCallback((tags: string[]) => {
+    setSelectedTags(tags);
+    setPage(0);
+  }, []);
+
   return {
     // Data
     items,
@@ -258,6 +271,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
     dateRange,
     selectedAssets,
     selectedMarketTypes,
+    selectedTags,
 
     // New item tracking
     isNew,
@@ -268,6 +282,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
     handleDateRangeChange,
     handleAssetChange,
     handleMarketTypeChange,
+    handleTagChange,
 
     // Refresh
     refresh,

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -7,10 +7,12 @@ import {
   GET_ACCOUNT_BY_ID,
   CREATE_ACCOUNT,
   DELETE_ACCOUNT,
+  UPDATE_ACCOUNT_TAGS,
   GET_WALLETS,
   GET_WALLETS_WITH_COUNTS,
   CREATE_WALLET,
   DELETE_WALLET,
+  UPDATE_WALLET_TAGS,
   GET_DISTINCT_TRADE_ASSETS,
   GET_DISTINCT_FUNDING_ASSETS,
   GET_DISTINCT_POSITION_ASSETS,
@@ -71,6 +73,18 @@ async function withErrorHandling<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+// Build tag filter conditions (OR logic - match accounts with ANY of the selected tags)
+function buildTagConditions(tags: string[]): Record<string, unknown> {
+  if (tags.length === 1) {
+    return { exchange_account: { tags: { _contains: tags[0] } } };
+  }
+  // Multiple tags: use OR logic
+  const tagConditions = tags.map(tag => ({
+    exchange_account: { tags: { _contains: tag } }
+  }));
+  return { _or: tagConditions };
+}
+
 // Build where clause for trades based on filters
 function buildTradesWhereClause(filters?: DataFilters): Record<string, unknown> {
   const conditions: Record<string, unknown>[] = [];
@@ -91,6 +105,10 @@ function buildTradesWhereClause(filters?: DataFilters): Record<string, unknown> 
 
   if (filters?.marketTypes && filters.marketTypes.length > 0) {
     conditions.push({ market_type: { _in: filters.marketTypes } });
+  }
+
+  if (filters?.tags && filters.tags.length > 0) {
+    conditions.push(buildTagConditions(filters.tags));
   }
 
   if (conditions.length === 0) {
@@ -122,6 +140,10 @@ function buildFundingWhereClause(filters?: DataFilters): Record<string, unknown>
     conditions.push({ base_asset: { _in: filters.baseAssets } });
   }
 
+  if (filters?.tags && filters.tags.length > 0) {
+    conditions.push(buildTagConditions(filters.tags));
+  }
+
   if (conditions.length === 0) {
     return {};
   }
@@ -149,6 +171,10 @@ function buildPositionsWhereClause(filters?: DataFilters): Record<string, unknow
 
   if (filters?.baseAssets && filters.baseAssets.length > 0) {
     conditions.push({ base_asset: { _in: filters.baseAssets } });
+  }
+
+  if (filters?.tags && filters.tags.length > 0) {
+    conditions.push(buildTagConditions(filters.tags));
   }
 
   if (conditions.length === 0) {
@@ -394,6 +420,26 @@ export const graphqlApi: ApiClient = {
         delete_wallets_by_pk: { id: string };
       }>(DELETE_WALLET, { id });
       return data.delete_wallets_by_pk;
+    });
+  },
+
+  async updateWalletTags(id: string, tags: string[]): Promise<{ id: string; tags: string[] }> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+      const data = await client.request<{
+        update_wallets_by_pk: { id: string; tags: string[] };
+      }>(UPDATE_WALLET_TAGS, { id, tags });
+      return data.update_wallets_by_pk;
+    });
+  },
+
+  async updateAccountTags(id: string, tags: string[]): Promise<{ id: string; tags: string[] }> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+      const data = await client.request<{
+        update_exchange_accounts_by_pk: { id: string; tags: string[] };
+      }>(UPDATE_ACCOUNT_TAGS, { id, tags });
+      return data.update_exchange_accounts_by_pk;
     });
   },
 };

--- a/src/lib/api/mock.ts
+++ b/src/lib/api/mock.ts
@@ -8,6 +8,7 @@ const mockWallets: Wallet[] = [
     address: "HN4xHDBPK7oSGGRafaJWS6jT8M7xyEk7Kos24xp27Kpq",
     chain: "solana",
     created_at: new Date().toISOString(),
+    tags: ["main", "trading"],
   },
 ];
 
@@ -34,6 +35,7 @@ const mockAccounts: ExchangeAccount[] = [
     account_type: "main",
     account_type_metadata: {},
     exchange: mockExchanges[0],
+    tags: ["main", "trading"],
   },
   {
     id: "mock-acc-002",
@@ -42,6 +44,7 @@ const mockAccounts: ExchangeAccount[] = [
     account_type: "main",
     account_type_metadata: {},
     exchange: mockExchanges[0],
+    tags: ["defi"],
   },
   {
     id: "mock-acc-003",
@@ -50,6 +53,7 @@ const mockAccounts: ExchangeAccount[] = [
     account_type: "main",
     account_type_metadata: {},
     exchange: mockExchanges[2],
+    tags: [],
   },
 ];
 
@@ -382,6 +386,7 @@ export const mockApi: ApiClient = {
       account_type: input.account_type,
       account_type_metadata: input.account_type_metadata,
       exchange,
+      tags: [],
     };
 
     mockAccounts.push(newAccount);
@@ -533,6 +538,7 @@ export const mockApi: ApiClient = {
       address: input.address,
       chain: input.chain,
       created_at: new Date().toISOString(),
+      tags: [],
     };
     mockWallets.push(newWallet);
     return newWallet;
@@ -546,5 +552,25 @@ export const mockApi: ApiClient = {
     }
     mockWallets.splice(index, 1);
     return { id };
+  },
+
+  async updateWalletTags(id: string, tags: string[]): Promise<{ id: string; tags: string[] }> {
+    await delay(200);
+    const wallet = mockWallets.find((w) => w.id === id);
+    if (!wallet) {
+      throw new Error("Wallet not found");
+    }
+    wallet.tags = tags;
+    return { id, tags };
+  },
+
+  async updateAccountTags(id: string, tags: string[]): Promise<{ id: string; tags: string[] }> {
+    await delay(200);
+    const account = mockAccounts.find((a) => a.id === id);
+    if (!account) {
+      throw new Error("Account not found");
+    }
+    account.tags = tags;
+    return { id, tags };
   },
 };

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -39,6 +39,7 @@ export interface DataFilters {
   until?: number;
   baseAssets?: string[];
   marketTypes?: ("perp" | "spot")[];
+  tags?: string[];
 }
 
 export interface ApiClient {
@@ -61,4 +62,6 @@ export interface ApiClient {
   getWalletsWithCounts(): Promise<WalletWithAccounts[]>;
   createWallet(input: CreateWalletInput): Promise<Wallet>;
   deleteWallet(id: string): Promise<{ id: string }>;
+  updateWalletTags(id: string, tags: string[]): Promise<{ id: string; tags: string[] }>;
+  updateAccountTags(id: string, tags: string[]): Promise<{ id: string; tags: string[] }>;
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -21,6 +21,7 @@ export interface ExchangeAccount {
   status?: string; // "active", "needs_token", "disabled"
   detected_at?: string;
   last_synced_at?: string;
+  tags: string[];
   exchange?: Exchange;
   wallet?: Wallet;
 }
@@ -32,6 +33,7 @@ export interface Wallet {
   chain: string;
   created_at: string;
   last_detected_at?: string;
+  tags: string[];
 }
 
 // Queries
@@ -65,6 +67,7 @@ export const GET_ACCOUNTS = gql`
       status
       detected_at
       last_synced_at
+      tags
       exchange {
         id
         name
@@ -88,6 +91,7 @@ export const GET_WALLETS = gql`
       chain
       created_at
       last_detected_at
+      tags
     }
   }
 `;
@@ -114,6 +118,15 @@ export const DELETE_WALLET = gql`
   }
 `;
 
+export const UPDATE_WALLET_TAGS = gql`
+  mutation UpdateWalletTags($id: uuid!, $tags: jsonb!) {
+    update_wallets_by_pk(pk_columns: { id: $id }, _set: { tags: $tags }) {
+      id
+      tags
+    }
+  }
+`;
+
 // Wallet with account count (for wallets section)
 export interface WalletWithAccounts extends Wallet {
   exchange_accounts_aggregate: {
@@ -131,6 +144,7 @@ export const GET_WALLETS_WITH_COUNTS = gql`
       chain
       created_at
       last_detected_at
+      tags
       exchange_accounts_aggregate {
         aggregate {
           count
@@ -210,6 +224,15 @@ export const DELETE_ACCOUNT = gql`
   mutation DeleteAccount($id: uuid!) {
     delete_exchange_accounts_by_pk(id: $id) {
       id
+    }
+  }
+`;
+
+export const UPDATE_ACCOUNT_TAGS = gql`
+  mutation UpdateAccountTags($id: uuid!, $tags: jsonb!) {
+    update_exchange_accounts_by_pk(pk_columns: { id: $id }, _set: { tags: $tags }) {
+      id
+      tags
     }
   }
 `;


### PR DESCRIPTION
Add user-defined tags for organizing accounts and wallets:

Components:
- TagBadge: styled badge for displaying tags
- TagInput: inline tag editor with autocomplete
- TagFilter: multi-select dropdown filter

Integration:
- WalletsSection: tags column with inline editing
- AccountsTable: tags column with inline editing
- Trades/Funding/Positions pages: tag filter in filter bar
- usePaginatedData hook: selectedTags state and filtering

GraphQL:
- Add tags field to Wallet and ExchangeAccount queries
- Add updateWalletTags and updateAccountTags mutations
- Add tag filtering to where clause builders (OR logic)