### PR TITLE
feat: add deposits page and improve open positions UI

### DIFF
--- a/src/app/(dashboard)/deposits/page.tsx
+++ b/src/app/(dashboard)/deposits/page.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { api, DataFilters } from "@/lib/api";
+import { Deposit, DepositsAggregates, ExchangeAccount } from "@/lib/queries";
+import { DepositsTable } from "@/components/deposits-table";
+import { SyncButton } from "@/components/sync-button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { StatCard, StatsGrid } from "@/components/stat-card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DateRangeFilter, DateRangeValue, getTimestampsFromDateRange } from "@/components/date-range-filter";
+import { AssetFilter } from "@/components/asset-filter";
+import { useAutoRefresh } from "@/hooks/use-auto-refresh";
+import { useNewItems } from "@/hooks/use-new-items";
+import { useApi } from "@/hooks/use-api";
+import { useFilters } from "@/contexts/filters-context";
+
+const PAGE_SIZE = 100;
+
+export default function DepositsPage() {
+  const { withErrorReporting } = useApi();
+  const { globalTags } = useFilters();
+
+  const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
+  const [availableAssets, setAvailableAssets] = useState<string[]>([]);
+  const [isLoadingAssets, setIsLoadingAssets] = useState(true);
+
+  // Data state
+  const [deposits, setDeposits] = useState<Deposit[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [aggregates, setAggregates] = useState<DepositsAggregates | null>(null);
+
+  // Loading states
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingAggregates, setIsLoadingAggregates] = useState(true);
+
+  // Pagination and filters
+  const [page, setPage] = useState(0);
+  const [selectedAccountId, setSelectedAccountId] = useState<string>("all");
+  const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
+  const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
+
+  // New item tracking
+  const { updateItems: updateNewItems, isNew } = useNewItems<Deposit>();
+
+  // Refs for auto-refresh
+  const pageRef = useRef(page);
+  const selectedAccountIdRef = useRef(selectedAccountId);
+  const dateRangeRef = useRef(dateRange);
+  const selectedAssetsRef = useRef(selectedAssets);
+  const globalTagsRef = useRef(globalTags);
+
+  useEffect(() => {
+    pageRef.current = page;
+    selectedAccountIdRef.current = selectedAccountId;
+    dateRangeRef.current = dateRange;
+    selectedAssetsRef.current = selectedAssets;
+    globalTagsRef.current = globalTags;
+  }, [page, selectedAccountId, dateRange, selectedAssets, globalTags]);
+
+  // Build filters object
+  const buildFilters = useCallback(
+    (accId: string, dateRangeValue: DateRangeValue, assets: string[], tags: string[]): DataFilters => {
+      const { since, until } = getTimestampsFromDateRange(dateRangeValue);
+      return {
+        accountId: accId === "all" ? undefined : accId,
+        since,
+        until,
+        baseAssets: assets.length > 0 ? assets : undefined,
+        tags: tags.length > 0 ? tags : undefined,
+      };
+    },
+    []
+  );
+
+  // Fetch aggregates
+  const doFetchAggregates = useCallback(
+    async (accId: string, dateRangeValue: DateRangeValue, assets: string[], tags: string[]) => {
+      setIsLoadingAggregates(true);
+      const filters = buildFilters(accId, dateRangeValue, assets, tags);
+
+      try {
+        const data = await withErrorReporting(() => api.getDepositsAggregates(filters));
+        setAggregates(data);
+      } catch (error) {
+        console.error("Failed to fetch aggregates:", error);
+      } finally {
+        setIsLoadingAggregates(false);
+      }
+    },
+    [withErrorReporting, buildFilters]
+  );
+
+  // Fetch deposits
+  const doFetchDeposits = useCallback(
+    async (pageNum: number, accId: string, dateRangeValue: DateRangeValue, assets: string[], tags: string[]) => {
+      setIsLoading(true);
+      const filters = buildFilters(accId, dateRangeValue, assets, tags);
+
+      try {
+        const data = await withErrorReporting(() =>
+          api.getDeposits(PAGE_SIZE, pageNum * PAGE_SIZE, filters)
+        );
+        setDeposits(data.deposits);
+        setTotalCount(data.totalCount);
+        updateNewItems(data.deposits);
+      } catch (error) {
+        console.error("Failed to fetch deposits:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [withErrorReporting, updateNewItems, buildFilters]
+  );
+
+  // Combined fetch for auto-refresh
+  const fetchAllData = useCallback(async () => {
+    await Promise.all([
+      doFetchDeposits(
+        pageRef.current,
+        selectedAccountIdRef.current,
+        dateRangeRef.current,
+        selectedAssetsRef.current,
+        globalTagsRef.current
+      ),
+      doFetchAggregates(
+        selectedAccountIdRef.current,
+        dateRangeRef.current,
+        selectedAssetsRef.current,
+        globalTagsRef.current
+      ),
+    ]);
+  }, [doFetchDeposits, doFetchAggregates]);
+
+  // Auto-refresh
+  const { lastRefreshTime, refresh } = useAutoRefresh(fetchAllData, {
+    interval: 30000,
+  });
+
+  // Initial fetch
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  // Refetch when filters change
+  useEffect(() => {
+    refresh();
+  }, [page, selectedAccountId, dateRange, selectedAssets, globalTags]);
+
+  useEffect(() => {
+    const fetchAccounts = async () => {
+      try {
+        const data = await api.getAccounts();
+        setAccounts(data);
+      } catch (error) {
+        console.error("Failed to fetch accounts:", error);
+      }
+    };
+    fetchAccounts();
+  }, []);
+
+  useEffect(() => {
+    const fetchAssets = async () => {
+      setIsLoadingAssets(true);
+      try {
+        const assets = await api.getDistinctDepositAssets();
+        setAvailableAssets(assets);
+      } catch (error) {
+        console.error("Failed to fetch assets:", error);
+      } finally {
+        setIsLoadingAssets(false);
+      }
+    };
+    fetchAssets();
+  }, []);
+
+  const formatAmount = (value: string) => {
+    const num = parseFloat(value);
+    return num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 });
+  };
+
+  const handlePageChange = useCallback((newPage: number) => {
+    setPage(newPage);
+  }, []);
+
+  const handleAccountChange = useCallback((newAccountId: string) => {
+    setSelectedAccountId(newAccountId);
+    setPage(0);
+  }, []);
+
+  const handleDateRangeChange = useCallback((newRange: DateRangeValue) => {
+    setDateRange(newRange);
+    setPage(0);
+  }, []);
+
+  const handleAssetChange = useCallback((assets: string[]) => {
+    setSelectedAssets(assets);
+    setPage(0);
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <div>
+          <h1 className="text-3xl font-bold">Deposits & Withdrawals</h1>
+          <p className="text-muted-foreground">
+            View all deposits and withdrawals across your exchange accounts
+          </p>
+        </div>
+        <SyncButton
+          lastRefreshTime={lastRefreshTime}
+          onRefresh={refresh}
+          isLoading={isLoading}
+        />
+      </div>
+
+      <StatsGrid>
+        <StatCard
+          title="Total Deposits"
+          value={aggregates ? formatAmount(aggregates.totalDeposits) : "0"}
+          isLoading={isLoadingAggregates}
+          valueClassName="text-green-500"
+        />
+        <StatCard
+          title="Total Withdrawals"
+          value={aggregates ? formatAmount(aggregates.totalWithdrawals) : "0"}
+          isLoading={isLoadingAggregates}
+          valueClassName="text-red-500"
+        />
+        <StatCard
+          title="Deposit Count"
+          value={aggregates?.depositCount.toLocaleString() || "0"}
+          isLoading={isLoadingAggregates}
+        />
+        <StatCard
+          title="Withdrawal Count"
+          value={aggregates?.withdrawalCount.toLocaleString() || "0"}
+          isLoading={isLoadingAggregates}
+        />
+      </StatsGrid>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle>
+            {selectedAccountId === "all" ? "All Records" : "Filtered Records"}
+          </CardTitle>
+          <div className="flex items-center gap-4">
+            <AssetFilter
+              assets={availableAssets}
+              selectedAssets={selectedAssets}
+              onSelectionChange={handleAssetChange}
+              isLoading={isLoadingAssets}
+            />
+            <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
+            <Select value={selectedAccountId} onValueChange={handleAccountChange}>
+              <SelectTrigger className="w-[280px]">
+                <SelectValue placeholder="Filter by account" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Accounts</SelectItem>
+                {accounts.map((account) => (
+                  <SelectItem key={account.id} value={account.id}>
+                    {account.exchange?.display_name || "Unknown"} - {account.account_identifier.slice(0, 10)}...
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <DepositsTable
+            deposits={deposits}
+            totalCount={totalCount}
+            page={page}
+            pageSize={PAGE_SIZE}
+            onPageChange={handlePageChange}
+            showAccount={true}
+            isLoading={isLoading}
+            isNewItem={isNew}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -14,6 +14,7 @@ const navigation = [
   { name: "Trades", href: "/trades" },
   { name: "Positions", href: "/positions" },
   { name: "Funding", href: "/funding" },
+  { name: "Deposits", href: "/deposits" },
 ];
 
 export default function DashboardLayout({

--- a/src/app/(dashboard)/positions/page.tsx
+++ b/src/app/(dashboard)/positions/page.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from "react";
 import { api, DataFilters } from "@/lib/api";
-import { Position, ExchangeAccount, PositionsAggregates } from "@/lib/queries";
+import { Position, ExchangeAccount, PositionsAggregates, OpenPosition } from "@/lib/queries";
 import { PositionsTable } from "@/components/positions-table";
+import { OpenPositionsTable } from "@/components/open-positions-table";
 import { SyncButton } from "@/components/sync-button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatCard, StatsGrid } from "@/components/stat-card";
@@ -16,6 +17,7 @@ import {
 } from "@/components/ui/select";
 import { DateRangeFilter } from "@/components/date-range-filter";
 import { AssetFilter } from "@/components/asset-filter";
+import { MarketTypeFilter } from "@/components/market-type-filter";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
 
 const PAGE_SIZE = 100;
@@ -37,6 +39,8 @@ export default function PositionsPage() {
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
   const [availableAssets, setAvailableAssets] = useState<string[]>([]);
   const [isLoadingAssets, setIsLoadingAssets] = useState(true);
+  const [openPositions, setOpenPositions] = useState<OpenPosition[]>([]);
+  const [isLoadingOpenPositions, setIsLoadingOpenPositions] = useState(true);
 
   const {
     items: positions,
@@ -48,11 +52,13 @@ export default function PositionsPage() {
     selectedAccountId,
     dateRange,
     selectedAssets,
+    selectedMarketTypes,
     isNew,
     handlePageChange,
     handleAccountChange,
     handleDateRangeChange,
     handleAssetChange,
+    handleMarketTypeChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<Position, PositionsAggregates>({
@@ -89,6 +95,32 @@ export default function PositionsPage() {
     fetchAssets();
   }, []);
 
+  // Fetch open positions
+  useEffect(() => {
+    const fetchOpenPositions = async () => {
+      setIsLoadingOpenPositions(true);
+      try {
+        const filters: DataFilters = {};
+        if (selectedAccountId && selectedAccountId !== "all") {
+          filters.accountId = selectedAccountId;
+        }
+        if (selectedAssets.length > 0) {
+          filters.baseAssets = selectedAssets;
+        }
+        if (selectedMarketTypes.length > 0) {
+          filters.marketTypes = selectedMarketTypes;
+        }
+        const positions = await api.getOpenPositions(filters);
+        setOpenPositions(positions);
+      } catch (error) {
+        console.error("Failed to fetch open positions:", error);
+      } finally {
+        setIsLoadingOpenPositions(false);
+      }
+    };
+    fetchOpenPositions();
+  }, [selectedAccountId, selectedAssets, selectedMarketTypes, lastRefreshTime]);
+
   const formatPnL = (value: string) => {
     const num = parseFloat(value);
     const sign = num >= 0 ? "+" : "";
@@ -106,9 +138,9 @@ export default function PositionsPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-2">
         <div>
-          <h1 className="text-3xl font-bold">Position History</h1>
+          <h1 className="text-3xl font-bold">Positions</h1>
           <p className="text-muted-foreground">
-            View all closed positions across your exchange accounts
+            View open and closed positions across your exchange accounts
           </p>
         </div>
         <SyncButton
@@ -138,33 +170,54 @@ export default function PositionsPage() {
         />
       </StatsGrid>
 
+      {/* Filters */}
+      <div className="flex items-center gap-4 flex-wrap">
+        <MarketTypeFilter
+          value={selectedMarketTypes}
+          onChange={handleMarketTypeChange}
+        />
+        <AssetFilter
+          assets={availableAssets}
+          selectedAssets={selectedAssets}
+          onSelectionChange={handleAssetChange}
+          isLoading={isLoadingAssets}
+        />
+        <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
+        <Select value={selectedAccountId} onValueChange={handleAccountChange}>
+          <SelectTrigger className="w-[280px]">
+            <SelectValue placeholder="Filter by account" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Accounts</SelectItem>
+            {accounts.map((account) => (
+              <SelectItem key={account.id} value={account.id}>
+                {account.exchange?.display_name || "Unknown"} - {account.account_identifier.slice(0, 10)}...
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Open Positions */}
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardHeader>
+          <CardTitle>Open Positions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <OpenPositionsTable
+            positions={openPositions}
+            showAccount={true}
+            isLoading={isLoadingOpenPositions}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Closed Positions */}
+      <Card>
+        <CardHeader>
           <CardTitle>
-            {selectedAccountId === "all" ? "All Positions" : "Filtered Positions"}
+            Closed Positions
           </CardTitle>
-          <div className="flex items-center gap-4">
-            <AssetFilter
-              assets={availableAssets}
-              selectedAssets={selectedAssets}
-              onSelectionChange={handleAssetChange}
-              isLoading={isLoadingAssets}
-            />
-            <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
-            <Select value={selectedAccountId} onValueChange={handleAccountChange}>
-              <SelectTrigger className="w-[280px]">
-                <SelectValue placeholder="Filter by account" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Accounts</SelectItem>
-                {accounts.map((account) => (
-                  <SelectItem key={account.id} value={account.id}>
-                    {account.exchange?.display_name || "Unknown"} - {account.account_identifier.slice(0, 10)}...
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
         </CardHeader>
         <CardContent>
           <PositionsTable

--- a/src/components/deposits-table.tsx
+++ b/src/components/deposits-table.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { Deposit } from "@/lib/queries";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { ExchangeBadge } from "@/components/exchange-badge";
+import { getDisplayName } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface DepositsTableProps {
+  deposits: Deposit[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  showAccount?: boolean;
+  isLoading?: boolean;
+  isNewItem?: (id: string) => boolean;
+}
+
+function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+function formatNumber(value: string, decimals: number = 6): string {
+  const num = parseFloat(value);
+  if (isNaN(num)) return value;
+  return num.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  });
+}
+
+function DepositsTableSkeleton({ rows = 5, showAccount = false }: { rows?: number; showAccount?: boolean }) {
+  return (
+    <div className="space-y-4">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Date</TableHead>
+            <TableHead>Asset</TableHead>
+            <TableHead>Direction</TableHead>
+            <TableHead className="text-right">Amount</TableHead>
+            <TableHead className="text-right">Cost Basis</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: rows }).map((_, i) => (
+            <TableRow key={i}>
+              <TableCell className="py-3">
+                <div className="flex flex-col gap-1">
+                  <Skeleton className="h-4 w-32" />
+                  {showAccount && <Skeleton className="h-3 w-24" />}
+                </div>
+              </TableCell>
+              <TableCell className="py-3">
+                <Skeleton className="h-4 w-16" />
+              </TableCell>
+              <TableCell className="py-3">
+                <Skeleton className="h-4 w-20" />
+              </TableCell>
+              <TableCell className="py-3 text-right">
+                <Skeleton className="h-4 w-24 ml-auto" />
+              </TableCell>
+              <TableCell className="py-3 text-right">
+                <Skeleton className="h-4 w-20 ml-auto" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function DepositsTable({
+  deposits,
+  totalCount,
+  page,
+  pageSize,
+  onPageChange,
+  showAccount = false,
+  isLoading = false,
+  isNewItem,
+}: DepositsTableProps) {
+  const totalPages = Math.ceil(totalCount / pageSize);
+  const startItem = page * pageSize + 1;
+  const endItem = Math.min((page + 1) * pageSize, totalCount);
+
+  if (isLoading && deposits.length === 0) {
+    return <DepositsTableSkeleton rows={5} showAccount={showAccount} />;
+  }
+
+  if (deposits.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <p className="text-muted-foreground mb-2">No deposits or withdrawals found</p>
+        <p className="text-sm text-muted-foreground">
+          Deposits and withdrawals will appear here once they are synced
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Date</TableHead>
+            <TableHead>Asset</TableHead>
+            <TableHead>Direction</TableHead>
+            <TableHead className="text-right">Amount</TableHead>
+            <TableHead className="text-right">Cost Basis</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {deposits.map((deposit) => {
+            const isDeposit = deposit.direction === "deposit";
+            return (
+              <TableRow
+                key={deposit.id}
+                className={cn(
+                  isNewItem?.(deposit.id) && "animate-highlight-new"
+                )}
+              >
+                <TableCell className="py-3 pl-0">
+                  <div className="flex">
+                    <div
+                      className={cn(
+                        "w-1 self-stretch rounded-full mr-3 flex-shrink-0",
+                        isDeposit ? "bg-green-500" : "bg-red-500"
+                      )}
+                    />
+                    <div className="flex flex-col">
+                      <span className="text-sm">
+                        {formatTimestamp(deposit.timestamp)}
+                      </span>
+                      {showAccount && (
+                        <div className="flex items-center gap-1.5 mt-0.5">
+                          <ExchangeBadge
+                            exchangeName={deposit.exchange_account?.exchange?.display_name || "Unknown"}
+                            className="text-[10px] px-1.5 py-0"
+                          />
+                          <span className="text-xs text-muted-foreground">
+                            {getDisplayName(
+                              deposit.exchange_account?.label,
+                              deposit.exchange_account?.account_identifier || deposit.exchange_account_id,
+                              8,
+                              4
+                            )}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell className="py-3">
+                  <span className="font-medium">{deposit.asset}</span>
+                </TableCell>
+                <TableCell className="py-3">
+                  <span
+                    className={cn(
+                      "font-medium uppercase",
+                      isDeposit ? "text-green-600" : "text-red-600"
+                    )}
+                  >
+                    {deposit.direction}
+                  </span>
+                </TableCell>
+                <TableCell className="py-3 text-right font-mono">
+                  <span className={cn(
+                    isDeposit ? "text-green-600" : "text-red-600"
+                  )}>
+                    {isDeposit ? "+" : "-"}{formatNumber(deposit.amount)}
+                  </span>
+                </TableCell>
+                <TableCell className="py-3 text-right font-mono text-muted-foreground">
+                  ${formatNumber(deposit.user_cost_basis, 2)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Showing {startItem} to {endItem} of {totalCount} records
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(page - 1)}
+            disabled={page === 0}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page {page + 1} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(page + 1)}
+            disabled={page >= totalPages - 1}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/market-type-filter.tsx
+++ b/src/components/market-type-filter.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-export type MarketType = "perp" | "spot";
+export type MarketType = "perp" | "spot" | "swap";
 
 interface MarketTypeFilterProps {
   value: MarketType[];
@@ -19,6 +19,7 @@ export function MarketTypeFilter({
   const isAll = value.length === 0;
   const isPerp = value.length === 1 && value[0] === "perp";
   const isSpot = value.length === 1 && value[0] === "spot";
+  const isSwap = value.length === 1 && value[0] === "swap";
 
   return (
     <div className={cn("flex items-center gap-1 p-1 bg-muted rounded-lg", className)}>
@@ -45,6 +46,14 @@ export function MarketTypeFilter({
         onClick={() => onChange(["spot"])}
       >
         Spot
+      </Button>
+      <Button
+        variant={isSwap ? "default" : "ghost"}
+        size="sm"
+        className="h-7 px-3 text-xs"
+        onClick={() => onChange(["swap"])}
+      >
+        Swap
       </Button>
     </div>
   );

--- a/src/components/open-positions-table.tsx
+++ b/src/components/open-positions-table.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { OpenPosition } from "@/lib/queries";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ExchangeBadge } from "@/components/exchange-badge";
+import { getDisplayName } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface OpenPositionsTableProps {
+  positions: OpenPosition[];
+  showAccount?: boolean;
+  isLoading?: boolean;
+}
+
+function formatNumber(value: number, decimals: number = 4): string {
+  if (isNaN(value)) return "0";
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  });
+}
+
+function formatPrice(value: number, decimals: number = 2): string {
+  if (isNaN(value) || value === 0) return "-";
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: decimals,
+  });
+}
+
+function OpenPositionsTableSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Asset</TableHead>
+          <TableHead>Side</TableHead>
+          <TableHead className="text-right">Size</TableHead>
+          <TableHead className="text-right">Entry</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: rows }).map((_, i) => (
+          <TableRow key={i}>
+            <TableCell>
+              <div className="space-y-1">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+            </TableCell>
+            <TableCell><Skeleton className="h-4 w-16" /></TableCell>
+            <TableCell className="text-right"><Skeleton className="h-4 w-20 ml-auto" /></TableCell>
+            <TableCell className="text-right"><Skeleton className="h-4 w-16 ml-auto" /></TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+// Perp positions table
+function PerpPositionsSection({
+  positions,
+}: {
+  positions: OpenPosition[];
+}) {
+  if (positions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-4 text-center">
+        <p className="text-muted-foreground text-sm">No open perp positions</p>
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Pair</TableHead>
+          <TableHead>Side</TableHead>
+          <TableHead className="text-right">Size</TableHead>
+          <TableHead className="text-right">Entry Price</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {positions.map((position, index) => (
+          <TableRow key={`${position.base_asset}-${position.quote_asset}-${position.exchange_account_id}-${index}`}>
+            <TableCell className="py-3">
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <div
+                    className={cn(
+                      "w-1 h-6 rounded-full flex-shrink-0",
+                      position.side === "long" ? "bg-green-500" : "bg-red-500"
+                    )}
+                  />
+                  <span className="font-medium">
+                    {position.base_asset}-{position.quote_asset}
+                  </span>
+                  <span className="text-[10px] font-medium px-1.5 py-0.5 rounded uppercase bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
+                    PERP
+                  </span>
+                </div>
+                <div className="flex items-center gap-1.5 ml-3">
+                  <ExchangeBadge
+                    exchangeName={position.exchange_account?.exchange?.display_name || "Unknown"}
+                    className="text-[10px] px-1.5 py-0"
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    {position.exchange_account?.label || getDisplayName(
+                      null,
+                      position.exchange_account?.account_identifier || position.exchange_account_id || "",
+                      8,
+                      4
+                    )}
+                  </span>
+                  {position.exchange_account?.tags && position.exchange_account.tags.length > 0 && (
+                    <div className="flex gap-1">
+                      {position.exchange_account.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </TableCell>
+            <TableCell className="py-3">
+              <span
+                className={cn(
+                  "font-medium",
+                  position.side === "long" ? "text-green-600" : "text-red-600"
+                )}
+              >
+                {position.side.toUpperCase()}
+              </span>
+            </TableCell>
+            <TableCell className="py-3 text-right font-mono">
+              {formatNumber(position.net_quantity)}
+            </TableCell>
+            <TableCell className="py-3 text-right font-mono">
+              ${formatPrice(position.avg_entry_price)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+// Spot positions table - shows asset and native quote
+function SpotPositionsSection({
+  positions,
+}: {
+  positions: OpenPosition[];
+}) {
+  if (positions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-4 text-center">
+        <p className="text-muted-foreground text-sm">No spot holdings</p>
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Asset</TableHead>
+          <TableHead>Side</TableHead>
+          <TableHead className="text-right">Balance</TableHead>
+          <TableHead className="text-right">Avg Cost</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {positions.map((position, index) => {
+          // Determine quote display
+          const nativeQuote = position.native_quote_asset || position.quote_asset;
+          const isUsdQuote = nativeQuote === "USDC" || nativeQuote === "USDT" || nativeQuote === "USD";
+          const priceDisplay = position.avg_entry_price > 0
+            ? isUsdQuote
+              ? `$${formatPrice(position.avg_entry_price)}`
+              : `${formatPrice(position.avg_entry_price, 4)} ${nativeQuote}`
+            : "-";
+
+          return (
+            <TableRow key={`${position.base_asset}-${position.exchange_account_id}-${index}`}>
+              <TableCell className="py-3">
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className={cn(
+                        "w-1 h-6 rounded-full flex-shrink-0",
+                        position.side === "long" ? "bg-green-500" : "bg-red-500"
+                      )}
+                    />
+                    <span className="font-medium">{position.base_asset}</span>
+                    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded uppercase bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                      SPOT
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1.5 ml-3">
+                    <ExchangeBadge
+                      exchangeName={position.exchange_account?.exchange?.display_name || "Unknown"}
+                      className="text-[10px] px-1.5 py-0"
+                    />
+                    <span className="text-xs text-muted-foreground">
+                      {position.exchange_account?.label || getDisplayName(
+                        null,
+                        position.exchange_account?.account_identifier || position.exchange_account_id || "",
+                        8,
+                        4
+                      )}
+                    </span>
+                    {position.exchange_account?.tags && position.exchange_account.tags.length > 0 && (
+                      <div className="flex gap-1">
+                        {position.exchange_account.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell className="py-3">
+                <span
+                  className={cn(
+                    "font-medium",
+                    position.side === "long" ? "text-green-600" : "text-red-600"
+                  )}
+                >
+                  {position.side.toUpperCase()}
+                </span>
+              </TableCell>
+              <TableCell className="py-3 text-right font-mono">
+                <span className={cn(
+                  position.side === "short" && "text-red-600"
+                )}>
+                  {position.side === "short" ? "-" : ""}
+                  {formatNumber(position.net_quantity)}
+                </span>
+              </TableCell>
+              <TableCell className="py-3 text-right font-mono text-muted-foreground">
+                {priceDisplay}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function OpenPositionsTable({
+  positions,
+  showAccount = false,
+  isLoading = false,
+}: OpenPositionsTableProps) {
+  if (isLoading && positions.length === 0) {
+    return <OpenPositionsTableSkeleton rows={3} />;
+  }
+
+  // Separate perp and spot positions
+  const perpPositions = positions.filter(p => p.market_type === "perp");
+  const spotPositions = positions.filter(p => p.market_type !== "perp");
+
+  const hasPositions = positions.length > 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Perp Positions */}
+      {(perpPositions.length > 0 || spotPositions.length === 0) && (
+        <div>
+          <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-purple-500"></span>
+            Perpetual Positions
+            {perpPositions.length > 0 && (
+              <span className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                {perpPositions.length}
+              </span>
+            )}
+          </h3>
+          <PerpPositionsSection positions={perpPositions} />
+        </div>
+      )}
+
+      {/* Spot Holdings */}
+      {(spotPositions.length > 0 || perpPositions.length === 0) && (
+        <div>
+          <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-blue-500"></span>
+            Spot Holdings
+            {spotPositions.length > 0 && (
+              <span className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                {spotPositions.length}
+              </span>
+            )}
+          </h3>
+          <SpotPositionsSection positions={spotPositions} />
+        </div>
+      )}
+
+      {!hasPositions && !isLoading && (
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <p className="text-muted-foreground">No open positions</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/position-detail.tsx
+++ b/src/components/position-detail.tsx
@@ -143,9 +143,19 @@ export function PositionDetail({ positionId }: PositionDetailProps) {
               <p className="text-sm font-medium text-muted-foreground">
                 Asset Pair
               </p>
-              <p className="text-lg font-semibold">
-                {position.base_asset}/{position.quote_asset}
-              </p>
+              <div className="flex items-center gap-2">
+                <p className="text-lg font-semibold">
+                  {position.base_asset}/{position.quote_asset}
+                </p>
+                <span className={cn(
+                  "text-[10px] font-medium px-1.5 py-0.5 rounded uppercase",
+                  position.market_type === "perp" && "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400",
+                  position.market_type === "spot" && "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+                  position.market_type === "swap" && "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400"
+                )}>
+                  {position.market_type?.toUpperCase() || "PERP"}
+                </span>
+              </div>
             </div>
             <div>
               <p className="text-sm font-medium text-muted-foreground">
@@ -213,7 +223,10 @@ export function PositionDetail({ positionId }: PositionDetailProps) {
               <p className="text-sm font-medium text-muted-foreground">
                 Total Fees
               </p>
-              <p className="text-lg font-mono text-red-600">
+              <p className={cn(
+                "text-lg font-mono",
+                parseFloat(position.total_fees) >= 0 ? "text-red-600" : "text-green-600"
+              )}>
                 {formatNumber(position.total_fees, 6)}
               </p>
             </div>

--- a/src/components/positions-table.tsx
+++ b/src/components/positions-table.tsx
@@ -150,8 +150,13 @@ export function PositionsTable({
                     <span className="font-medium">
                       {position.base_asset}/{position.quote_asset}
                     </span>
-                    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded uppercase bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
-                      PERP
+                    <span className={cn(
+                      "text-[10px] font-medium px-1.5 py-0.5 rounded uppercase",
+                      position.market_type === "perp" && "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400",
+                      position.market_type === "spot" && "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+                      position.market_type === "swap" && "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400"
+                    )}>
+                      {position.market_type?.toUpperCase() || "PERP"}
                     </span>
                   </div>
                 </TableCell>
@@ -177,7 +182,11 @@ export function PositionsTable({
                   {formatNumber(position.total_quantity)}
                 </TableCell>
                 <TableCell className="py-3 text-right font-mono">
-                  {formatNumber(position.total_fees, 6)}
+                  <span className={cn(
+                    parseFloat(position.total_fees) >= 0 ? "text-red-600" : "text-green-600"
+                  )}>
+                    {formatNumber(position.total_fees, 6)}
+                  </span>
                 </TableCell>
                 <TableCell className={cn("py-3 text-right font-mono font-medium", pnl.className)}>
                   {pnl.text}

--- a/src/components/trades-table.tsx
+++ b/src/components/trades-table.tsx
@@ -132,6 +132,8 @@ export function TradesTable({
                       "text-[10px] font-medium px-1.5 py-0.5 rounded uppercase",
                       trade.market_type === "spot"
                         ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                        : trade.market_type === "swap"
+                        ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
                         : "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400"
                     )}
                   >
@@ -156,7 +158,11 @@ export function TradesTable({
                 {formatNumber(trade.quantity)}
               </TableCell>
               <TableCell className="py-3 text-right font-mono">
-                {formatNumber(trade.fee, 6)}
+                <span className={cn(
+                  parseFloat(trade.fee) >= 0 ? "text-red-600" : "text-green-600"
+                )}>
+                  {formatNumber(trade.fee, 6)}
+                </span>
               </TableCell>
             </TableRow>
           ))}

--- a/src/hooks/use-paginated-data.ts
+++ b/src/hooks/use-paginated-data.ts
@@ -55,7 +55,7 @@ export interface UsePaginatedDataResult<TItem, TAggregates> {
   selectedAccountId: string;
   dateRange: DateRangeValue;
   selectedAssets: string[];
-  selectedMarketTypes: ("perp" | "spot")[];
+  selectedMarketTypes: ("perp" | "spot" | "swap")[];
   selectedTags: string[];
 
   // New item tracking
@@ -66,7 +66,7 @@ export interface UsePaginatedDataResult<TItem, TAggregates> {
   handleAccountChange: (accountId: string) => void;
   handleDateRangeChange: (newRange: DateRangeValue) => void;
   handleAssetChange: (assets: string[]) => void;
-  handleMarketTypeChange: (marketTypes: ("perp" | "spot")[]) => void;
+  handleMarketTypeChange: (marketTypes: ("perp" | "spot" | "swap")[]) => void;
   handleTagChange: (tags: string[]) => void;
 
   // Refresh
@@ -106,7 +106,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
   const [selectedAccountId, setSelectedAccountId] = useState<string>(accountId ?? "all");
   const [dateRange, setDateRange] = useState<DateRangeValue>({ preset: "all" });
   const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
-  const [selectedMarketTypes, setSelectedMarketTypes] = useState<("perp" | "spot")[]>([]);
+  const [selectedMarketTypes, setSelectedMarketTypes] = useState<("perp" | "spot" | "swap")[]>([]);
   const [localSelectedTags, setLocalSelectedTags] = useState<string[]>([]);
 
   // Use global tags if configured, otherwise use local state
@@ -134,7 +134,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
 
   // Build filters object from current state
   const buildFilters = useCallback(
-    (accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[], tags: string[]): DataFilters => {
+    (accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot" | "swap")[], tags: string[]): DataFilters => {
       const { since, until } = getTimestampsFromDateRange(dateRangeValue);
       return {
         accountId: accId === "all" ? undefined : accId,
@@ -150,7 +150,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
 
   // Fetch aggregates
   const doFetchAggregates = useCallback(
-    async (accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[], tags: string[]) => {
+    async (accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot" | "swap")[], tags: string[]) => {
       setIsLoadingAggregates(true);
       const filters = buildFilters(accId, dateRangeValue, assets, marketTypes, tags);
 
@@ -168,7 +168,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
 
   // Fetch items
   const doFetchItems = useCallback(
-    async (pageNum: number, accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot")[], tags: string[]) => {
+    async (pageNum: number, accId: string, dateRangeValue: DateRangeValue, assets: string[], marketTypes: ("perp" | "spot" | "swap")[], tags: string[]) => {
       setIsLoading(true);
       const filters = buildFilters(accId, dateRangeValue, assets, marketTypes, tags);
 
@@ -251,7 +251,7 @@ export function usePaginatedData<TItem extends { id: string }, TAggregates>(
     setPage(0);
   }, []);
 
-  const handleMarketTypeChange = useCallback((marketTypes: ("perp" | "spot")[]) => {
+  const handleMarketTypeChange = useCallback((marketTypes: ("perp" | "spot" | "swap")[]) => {
     setSelectedMarketTypes(marketTypes);
     setPage(0);
   }, []);

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -1,5 +1,6 @@
 import Cookies from "js-cookie";
 import { getGraphQLClient, TOKEN_COOKIE_NAME } from "../graphql-client";
+import { gql } from "graphql-request";
 import {
   GET_EXCHANGES,
   GET_ACCOUNT_TYPES,
@@ -17,6 +18,7 @@ import {
   GET_DISTINCT_TRADE_ASSETS,
   GET_DISTINCT_FUNDING_ASSETS,
   GET_DISTINCT_POSITION_ASSETS,
+  GET_DISTINCT_DEPOSIT_ASSETS,
   GET_TRADES_DYNAMIC,
   GET_TRADES_AGGREGATES_DYNAMIC,
   GET_FUNDING_PAYMENTS_DYNAMIC,
@@ -24,6 +26,8 @@ import {
   GET_POSITIONS_DYNAMIC,
   GET_POSITIONS_AGGREGATES_DYNAMIC,
   GET_POSITION_WITH_TRADES,
+  GET_DEPOSITS_DYNAMIC,
+  GET_DEPOSITS_AGGREGATES_DYNAMIC,
   Exchange,
   ExchangeAccount,
   ExchangeAccountType,
@@ -36,8 +40,11 @@ import {
   PositionsAggregates,
   Wallet,
   WalletWithAccounts,
+  Deposit,
+  DepositsAggregates,
+  OpenPosition,
 } from "../queries";
-import { ApiClient, CreateAccountInput, CreateWalletInput, TradesResult, FundingPaymentsResult, PositionsResult, PositionWithTrades, DataFilters } from "./types";
+import { ApiClient, CreateAccountInput, CreateWalletInput, TradesResult, FundingPaymentsResult, PositionsResult, PositionWithTrades, DepositsResult, DataFilters } from "./types";
 import { ApiError } from "./errors";
 
 function isAuthError(error: unknown): boolean {
@@ -172,6 +179,43 @@ function buildPositionsWhereClause(filters?: DataFilters): Record<string, unknow
 
   if (filters?.baseAssets && filters.baseAssets.length > 0) {
     conditions.push({ base_asset: { _in: filters.baseAssets } });
+  }
+
+  if (filters?.marketTypes && filters.marketTypes.length > 0) {
+    conditions.push({ market_type: { _in: filters.marketTypes } });
+  }
+
+  if (filters?.tags && filters.tags.length > 0) {
+    conditions.push(buildTagConditions(filters.tags));
+  }
+
+  if (conditions.length === 0) {
+    return {};
+  }
+
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
+
+  return { _and: conditions };
+}
+
+// Build where clause for deposits based on filters
+function buildDepositsWhereClause(filters?: DataFilters): Record<string, unknown> {
+  const conditions: Record<string, unknown>[] = [];
+
+  if (filters?.accountId) {
+    conditions.push({ exchange_account_id: { _eq: filters.accountId } });
+  }
+
+  if (filters?.since !== undefined && filters?.until !== undefined) {
+    conditions.push({ timestamp: { _gte: String(filters.since), _lte: String(filters.until) } });
+  } else if (filters?.since !== undefined) {
+    conditions.push({ timestamp: { _gte: String(filters.since) } });
+  }
+
+  if (filters?.baseAssets && filters.baseAssets.length > 0) {
+    conditions.push({ asset: { _in: filters.baseAssets } });
   }
 
   if (filters?.tags && filters.tags.length > 0) {
@@ -387,6 +431,67 @@ export const graphqlApi: ApiClient = {
     });
   },
 
+  // Deposit methods
+  async getDeposits(limit: number, offset: number, filters?: DataFilters): Promise<DepositsResult> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+      const where = buildDepositsWhereClause(filters);
+
+      const data = await client.request<{
+        deposits: Deposit[];
+        deposits_aggregate: { aggregate: { count: number } };
+      }>(GET_DEPOSITS_DYNAMIC, { limit, offset, where });
+
+      return {
+        deposits: data.deposits,
+        totalCount: data.deposits_aggregate.aggregate.count,
+      };
+    });
+  },
+
+  async getDepositsAggregates(filters?: DataFilters): Promise<DepositsAggregates> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+      const where = buildDepositsWhereClause(filters);
+
+      const data = await client.request<{
+        deposits: {
+          aggregate: {
+            count: number;
+            sum: { amount: string | null };
+          };
+        };
+        deposit_totals: {
+          aggregate: {
+            count: number;
+            sum: { amount: string | null };
+          };
+        };
+        withdrawal_totals: {
+          aggregate: {
+            count: number;
+            sum: { amount: string | null };
+          };
+        };
+      }>(GET_DEPOSITS_AGGREGATES_DYNAMIC, { where });
+
+      return {
+        totalDeposits: data.deposit_totals.aggregate.sum.amount || "0",
+        totalWithdrawals: data.withdrawal_totals.aggregate.sum.amount || "0",
+        depositCount: data.deposit_totals.aggregate.count,
+        withdrawalCount: data.withdrawal_totals.aggregate.count,
+      };
+    });
+  },
+
+  async getDistinctDepositAssets(): Promise<string[]> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+      const data = await client.request<{ deposits: { asset: string }[] }>(GET_DISTINCT_DEPOSIT_ASSETS);
+      return data.deposits.map((d) => d.asset);
+    });
+  },
+
   // Wallet methods
   async getWallets(): Promise<Wallet[]> {
     return withErrorHandling(async () => {
@@ -451,6 +556,327 @@ export const graphqlApi: ApiClient = {
         update_exchange_accounts_by_pk: { id: string; label: string | null };
       }>(UPDATE_ACCOUNT_LABEL, { id, label });
       return data.update_exchange_accounts_by_pk;
+    });
+  },
+
+  async getOpenPositions(filters?: DataFilters): Promise<OpenPosition[]> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+
+      // Build base where clause for filtering
+      const baseConditions: Record<string, unknown>[] = [];
+      if (filters?.accountId) {
+        baseConditions.push({ exchange_account_id: { _eq: filters.accountId } });
+      }
+      if (filters?.tags && filters.tags.length > 0) {
+        baseConditions.push(buildTagConditions(filters.tags));
+      }
+
+      const baseWhere = baseConditions.length > 0 ? { _and: baseConditions } : {};
+
+      // First, get all trades
+      const tradesQuery = gql`
+        query GetAllTrades($where: trades_bool_exp!) {
+          trades(where: $where, order_by: { timestamp: asc }) {
+            base_asset
+            quote_asset
+            side
+            price
+            quantity
+            market_type
+            exchange_account_id
+            exchange_account {
+              id
+              account_identifier
+              label
+              exchange {
+                id
+                name
+                display_name
+              }
+            }
+          }
+        }
+      `;
+
+      const tradesData = await client.request<{
+        trades: Array<{
+          base_asset: string;
+          quote_asset: string;
+          side: string;
+          price: string;
+          quantity: string;
+          market_type: string;
+          exchange_account_id: string;
+          exchange_account: ExchangeAccount;
+        }>;
+      }>(tradesQuery, { where: baseWhere });
+
+      // Track positions with entry price calculation
+      // For perp: track by base/quote/account
+      // For spot: track by asset/account (asset-based)
+      interface PositionEntry {
+        netQty: number;
+        totalCost: number; // For weighted avg entry: sum of (qty * price) for entries
+        totalEntryQty: number; // Sum of entry quantities
+        account: ExchangeAccount;
+        nativeQuoteAsset?: string; // For spot: the quote asset used (e.g., SOL for bSOL/SOL)
+      }
+
+      // Perp positions: base_asset/quote_asset/account -> PositionEntry
+      const perpPositions = new Map<string, PositionEntry>();
+
+      // Spot positions: asset/account -> PositionEntry
+      const spotPositions = new Map<string, PositionEntry>();
+
+      const getPerpKey = (base: string, quote: string, accountId: string) =>
+        `${base}/${quote}/${accountId}`;
+
+      const getSpotKey = (asset: string, accountId: string) =>
+        `${asset}/${accountId}`;
+
+      // Process perp trades (pair-based)
+      for (const trade of tradesData.trades) {
+        if (trade.market_type !== "perp") continue;
+
+        const price = parseFloat(trade.price);
+        const qty = parseFloat(trade.quantity);
+        const key = getPerpKey(trade.base_asset, trade.quote_asset, trade.exchange_account_id);
+
+        if (!perpPositions.has(key)) {
+          perpPositions.set(key, {
+            netQty: 0,
+            totalCost: 0,
+            totalEntryQty: 0,
+            account: trade.exchange_account,
+          });
+        }
+
+        const pos = perpPositions.get(key)!;
+        const prevQty = pos.netQty;
+        const delta = trade.side === "buy" ? qty : -qty;
+        pos.netQty += delta;
+
+        // Track entry price: only count trades that add to position
+        const isAddingToPosition =
+          (prevQty >= 0 && trade.side === "buy") ||
+          (prevQty <= 0 && trade.side === "sell");
+
+        if (isAddingToPosition) {
+          pos.totalCost += price * qty;
+          pos.totalEntryQty += qty;
+        }
+      }
+
+      // Process spot/swap trades (asset-based)
+      for (const trade of tradesData.trades) {
+        if (trade.market_type === "perp") continue;
+
+        const price = parseFloat(trade.price);
+        const qty = parseFloat(trade.quantity);
+        const quoteQty = price * qty;
+
+        // Base asset movement
+        if (trade.base_asset !== "USDC" && trade.base_asset !== "USDT") {
+          const key = getSpotKey(trade.base_asset, trade.exchange_account_id);
+
+          if (!spotPositions.has(key)) {
+            spotPositions.set(key, {
+              netQty: 0,
+              totalCost: 0,
+              totalEntryQty: 0,
+              account: trade.exchange_account,
+              nativeQuoteAsset: trade.quote_asset,
+            });
+          }
+
+          const pos = spotPositions.get(key)!;
+          const prevQty = pos.netQty;
+          const delta = trade.side === "buy" ? qty : -qty;
+          pos.netQty += delta;
+
+          // Track entry: buying adds to long, selling adds to short
+          const isAddingToPosition =
+            (prevQty >= 0 && trade.side === "buy") ||
+            (prevQty <= 0 && trade.side === "sell");
+
+          if (isAddingToPosition) {
+            pos.totalCost += price * qty;
+            pos.totalEntryQty += qty;
+            // Update native quote if this is a non-USD quote
+            if (trade.quote_asset !== "USDC" && trade.quote_asset !== "USDT") {
+              pos.nativeQuoteAsset = trade.quote_asset;
+            }
+          }
+        }
+
+        // Quote asset movement (for non-stablecoin quotes)
+        if (
+          trade.quote_asset !== "USDC" &&
+          trade.quote_asset !== "USDT"
+        ) {
+          const key = getSpotKey(trade.quote_asset, trade.exchange_account_id);
+
+          if (!spotPositions.has(key)) {
+            spotPositions.set(key, {
+              netQty: 0,
+              totalCost: 0,
+              totalEntryQty: 0,
+              account: trade.exchange_account,
+              nativeQuoteAsset: trade.base_asset, // When SOL is quote, base is the "quote" for SOL
+            });
+          }
+
+          const pos = spotPositions.get(key)!;
+          const prevQty = pos.netQty;
+          // Buy base = spend quote, Sell base = receive quote
+          const delta = trade.side === "buy" ? -quoteQty : quoteQty;
+          pos.netQty += delta;
+
+          // Entry tracking for quote asset
+          const isAddingToPosition =
+            (prevQty >= 0 && delta > 0) ||
+            (prevQty <= 0 && delta < 0);
+
+          if (isAddingToPosition) {
+            // Price is inverted: 1/original_price since we're tracking quote
+            pos.totalCost += Math.abs(quoteQty) * (1 / price);
+            pos.totalEntryQty += Math.abs(quoteQty);
+          }
+        }
+      }
+
+      // Fetch deposits
+      const depositsQuery = gql`
+        query GetAllDeposits($where: deposits_bool_exp!) {
+          deposits(where: $where) {
+            asset
+            direction
+            amount
+            user_cost_basis
+            exchange_account_id
+            exchange_account {
+              id
+              account_identifier
+              label
+              exchange {
+                id
+                name
+                display_name
+              }
+            }
+          }
+        }
+      `;
+
+      const depositsData = await client.request<{
+        deposits: Array<{
+          asset: string;
+          direction: string;
+          amount: string;
+          user_cost_basis: string;
+          exchange_account_id: string;
+          exchange_account: ExchangeAccount;
+        }>;
+      }>(depositsQuery, { where: baseWhere });
+
+      // Process deposits
+      for (const deposit of depositsData.deposits) {
+        if (deposit.asset === "USDC" || deposit.asset === "USDT") continue;
+
+        const qty = parseFloat(deposit.amount);
+        const costBasis = parseFloat(deposit.user_cost_basis) || 0;
+        const key = getSpotKey(deposit.asset, deposit.exchange_account_id);
+
+        if (!spotPositions.has(key)) {
+          spotPositions.set(key, {
+            netQty: 0,
+            totalCost: 0,
+            totalEntryQty: 0,
+            account: deposit.exchange_account,
+            nativeQuoteAsset: "USDC",
+          });
+        }
+
+        const pos = spotPositions.get(key)!;
+        const prevQty = pos.netQty;
+        const delta = deposit.direction === "deposit" ? qty : -qty;
+        pos.netQty += delta;
+
+        // Deposits add to position (entry)
+        if (deposit.direction === "deposit" && prevQty >= 0) {
+          pos.totalCost += costBasis * qty;
+          pos.totalEntryQty += qty;
+        }
+      }
+
+      // Apply filters
+      const assetsToInclude = filters?.baseAssets && filters.baseAssets.length > 0
+        ? new Set(filters.baseAssets)
+        : null;
+      const marketTypesToInclude = filters?.marketTypes && filters.marketTypes.length > 0
+        ? new Set(filters.marketTypes)
+        : null;
+
+      const openPositions: OpenPosition[] = [];
+
+      // Convert perp positions
+      if (!marketTypesToInclude || marketTypesToInclude.has("perp")) {
+        for (const [key, pos] of perpPositions) {
+          if (Math.abs(pos.netQty) < 0.0001) continue;
+
+          const [base, quote] = key.split("/");
+          if (assetsToInclude && !assetsToInclude.has(base)) continue;
+
+          const avgEntryPrice = pos.totalEntryQty > 0
+            ? pos.totalCost / pos.totalEntryQty
+            : 0;
+
+          openPositions.push({
+            base_asset: base,
+            quote_asset: quote,
+            market_type: "perp",
+            side: pos.netQty > 0 ? "long" : "short",
+            net_quantity: Math.abs(pos.netQty),
+            avg_entry_price: avgEntryPrice,
+            total_cost: pos.totalCost,
+            exchange_account_id: key.split("/")[2],
+            exchange_account: pos.account,
+          });
+        }
+      }
+
+      // Convert spot positions
+      if (!marketTypesToInclude || marketTypesToInclude.has("spot")) {
+        for (const [key, pos] of spotPositions) {
+          if (Math.abs(pos.netQty) < 0.0001) continue;
+
+          const [asset] = key.split("/");
+          if (assetsToInclude && !assetsToInclude.has(asset)) continue;
+
+          const avgEntryPrice = pos.totalEntryQty > 0
+            ? pos.totalCost / pos.totalEntryQty
+            : 0;
+
+          openPositions.push({
+            base_asset: asset,
+            quote_asset: pos.nativeQuoteAsset || "USDC",
+            market_type: "spot",
+            side: pos.netQty > 0 ? "long" : "short",
+            net_quantity: Math.abs(pos.netQty),
+            avg_entry_price: avgEntryPrice,
+            total_cost: pos.totalCost,
+            exchange_account_id: key.split("/")[1],
+            exchange_account: pos.account,
+            native_quote_asset: pos.nativeQuoteAsset,
+          });
+        }
+      }
+
+      // Sort by quantity descending
+      openPositions.sort((a, b) => b.net_quantity - a.net_quantity);
+
+      return openPositions;
     });
   },
 };

--- a/src/lib/api/mock.ts
+++ b/src/lib/api/mock.ts
@@ -1,5 +1,5 @@
-import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates, Position, PositionsAggregates, Wallet, WalletWithAccounts } from "../queries";
-import { ApiClient, CreateAccountInput, CreateWalletInput, TradesResult, FundingPaymentsResult, PositionsResult, PositionWithTrades, DataFilters } from "./types";
+import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates, Position, PositionsAggregates, Wallet, WalletWithAccounts, Deposit, DepositsAggregates, OpenPosition } from "../queries";
+import { ApiClient, CreateAccountInput, CreateWalletInput, TradesResult, FundingPaymentsResult, PositionsResult, PositionWithTrades, DepositsResult, DataFilters } from "./types";
 
 // Mock wallets
 const mockWallets: Wallet[] = [
@@ -211,6 +211,7 @@ const mockPositions: Position[] = [
     base_asset: "ETH",
     quote_asset: "USDC",
     side: "long",
+    market_type: "perp",
     start_time: Date.now() - 1000 * 60 * 60 * 24, // 1 day ago
     end_time: Date.now() - 1000 * 60 * 60 * 12, // 12 hours ago
     entry_avg_price: "3200.00",
@@ -226,6 +227,7 @@ const mockPositions: Position[] = [
     base_asset: "BTC",
     quote_asset: "USDC",
     side: "short",
+    market_type: "perp",
     start_time: Date.now() - 1000 * 60 * 60 * 48, // 2 days ago
     end_time: Date.now() - 1000 * 60 * 60 * 36, // 1.5 days ago
     entry_avg_price: "98000.00",
@@ -241,6 +243,7 @@ const mockPositions: Position[] = [
     base_asset: "SOL",
     quote_asset: "USDC",
     side: "long",
+    market_type: "perp",
     start_time: Date.now() - 1000 * 60 * 60 * 72, // 3 days ago
     end_time: Date.now() - 1000 * 60 * 60 * 60, // 2.5 days ago
     entry_avg_price: "180.00",
@@ -256,6 +259,7 @@ const mockPositions: Position[] = [
     base_asset: "ETH",
     quote_asset: "USDT",
     side: "short",
+    market_type: "spot",
     start_time: Date.now() - 1000 * 60 * 60 * 96, // 4 days ago
     end_time: Date.now() - 1000 * 60 * 60 * 84, // 3.5 days ago
     entry_avg_price: "3150.00",
@@ -264,6 +268,43 @@ const mockPositions: Position[] = [
     total_fees: "0.0005",
     realized_pnl: "-50.05",
     exchange_account: mockAccounts[2],
+  },
+];
+
+// Mock deposits
+const mockDeposits: Deposit[] = [
+  {
+    id: "mock-deposit-001",
+    exchange_account_id: "mock-acc-001",
+    asset: "SOL",
+    direction: "deposit",
+    amount: "100.5",
+    user_cost_basis: "180.00",
+    timestamp: Date.now() - 1000 * 60 * 60 * 24 * 7, // 1 week ago
+    deposit_id: "sol-deposit-001",
+    exchange_account: mockAccounts[0],
+  },
+  {
+    id: "mock-deposit-002",
+    exchange_account_id: "mock-acc-001",
+    asset: "USDC",
+    direction: "deposit",
+    amount: "10000",
+    user_cost_basis: "1.00",
+    timestamp: Date.now() - 1000 * 60 * 60 * 24 * 5, // 5 days ago
+    deposit_id: "usdc-deposit-001",
+    exchange_account: mockAccounts[0],
+  },
+  {
+    id: "mock-deposit-003",
+    exchange_account_id: "mock-acc-002",
+    asset: "SOL",
+    direction: "withdraw",
+    amount: "50.25",
+    user_cost_basis: "190.00",
+    timestamp: Date.now() - 1000 * 60 * 60 * 24 * 3, // 3 days ago
+    deposit_id: "sol-withdraw-001",
+    exchange_account: mockAccounts[1],
   },
 ];
 
@@ -338,6 +379,29 @@ function filterPositions(positions: Position[], filters?: DataFilters): Position
 
   if (filters?.baseAssets && filters.baseAssets.length > 0) {
     result = result.filter((position) => filters.baseAssets!.includes(position.base_asset));
+  }
+
+  return result;
+}
+
+// Filter deposits based on DataFilters
+function filterDeposits(deposits: Deposit[], filters?: DataFilters): Deposit[] {
+  let result = deposits;
+
+  if (filters?.accountId) {
+    result = result.filter((deposit) => deposit.exchange_account_id === filters.accountId);
+  }
+
+  if (filters?.since) {
+    result = result.filter((deposit) => deposit.timestamp >= filters.since!);
+  }
+
+  if (filters?.until) {
+    result = result.filter((deposit) => deposit.timestamp <= filters.until!);
+  }
+
+  if (filters?.baseAssets && filters.baseAssets.length > 0) {
+    result = result.filter((deposit) => filters.baseAssets!.includes(deposit.asset));
   }
 
   return result;
@@ -507,6 +571,40 @@ export const mockApi: ApiClient = {
     };
   },
 
+  // Deposit methods
+  async getDeposits(limit: number, offset: number, filters?: DataFilters): Promise<DepositsResult> {
+    await delay(300);
+    const filteredDeposits = filterDeposits(mockDeposits, filters);
+    const paginatedDeposits = filteredDeposits.slice(offset, offset + limit);
+    return {
+      deposits: paginatedDeposits,
+      totalCount: filteredDeposits.length,
+    };
+  },
+
+  async getDepositsAggregates(filters?: DataFilters): Promise<DepositsAggregates> {
+    await delay(200);
+    const filteredDeposits = filterDeposits(mockDeposits, filters);
+    const deposits = filteredDeposits.filter((d) => d.direction === "deposit");
+    const withdrawals = filteredDeposits.filter((d) => d.direction === "withdraw");
+
+    const totalDeposits = deposits.reduce((sum, d) => sum + parseFloat(d.amount), 0);
+    const totalWithdrawals = withdrawals.reduce((sum, d) => sum + parseFloat(d.amount), 0);
+
+    return {
+      totalDeposits: totalDeposits.toString(),
+      totalWithdrawals: totalWithdrawals.toString(),
+      depositCount: deposits.length,
+      withdrawalCount: withdrawals.length,
+    };
+  },
+
+  async getDistinctDepositAssets(): Promise<string[]> {
+    await delay(200);
+    const assets = [...new Set(mockDeposits.map((d) => d.asset))];
+    return assets.sort();
+  },
+
   // Wallet methods
   async getWallets(): Promise<Wallet[]> {
     await delay(200);
@@ -584,5 +682,142 @@ export const mockApi: ApiClient = {
     }
     account.label = label || undefined;
     return { id, label };
+  },
+
+  async getOpenPositions(filters?: DataFilters): Promise<OpenPosition[]> {
+    await delay(300);
+
+    // Asset-based position tracking:
+    // - As base_asset: buy = +qty, sell = -qty
+    // - As quote_asset: buy = -(price*qty), sell = +(price*qty)
+
+    let filteredTrades = mockTrades;
+    if (filters?.accountId) {
+      filteredTrades = filteredTrades.filter((t) => t.exchange_account_id === filters.accountId);
+    }
+
+    // Map: asset -> accountId -> marketType -> { netQty, account }
+    const assetBalances = new Map<string, Map<string, Map<string, { netQty: number; account: ExchangeAccount }>>>();
+
+    const updateBalance = (
+      asset: string,
+      accountId: string,
+      marketType: string,
+      delta: number,
+      account?: ExchangeAccount
+    ) => {
+      const normalizedMarketType = marketType === "swap" ? "spot" : marketType;
+
+      if (!assetBalances.has(asset)) {
+        assetBalances.set(asset, new Map());
+      }
+      const assetMap = assetBalances.get(asset)!;
+
+      if (!assetMap.has(accountId)) {
+        assetMap.set(accountId, new Map());
+      }
+      const accountMap = assetMap.get(accountId)!;
+
+      if (!accountMap.has(normalizedMarketType)) {
+        accountMap.set(normalizedMarketType, { netQty: 0, account: account || mockAccounts[0] });
+      }
+
+      const entry = accountMap.get(normalizedMarketType)!;
+      entry.netQty += delta;
+      if (account) entry.account = account;
+    };
+
+    for (const trade of filteredTrades) {
+      const price = parseFloat(trade.price);
+      const qty = parseFloat(trade.quantity);
+      const quoteQty = price * qty;
+
+      // Base asset: buy = +qty, sell = -qty
+      if (trade.base_asset !== "USDC" && trade.base_asset !== "USDT") {
+        const baseDelta = trade.side === "buy" ? qty : -qty;
+        updateBalance(
+          trade.base_asset,
+          trade.exchange_account_id,
+          trade.market_type,
+          baseDelta,
+          trade.exchange_account
+        );
+      }
+
+      // Quote asset: buy = -(price*qty), sell = +(price*qty)
+      // Skip stablecoins and perp quote tracking
+      if (
+        trade.quote_asset !== "USDC" &&
+        trade.quote_asset !== "USDT" &&
+        trade.market_type !== "perp"
+      ) {
+        const quoteDelta = trade.side === "buy" ? -quoteQty : quoteQty;
+        updateBalance(
+          trade.quote_asset,
+          trade.exchange_account_id,
+          trade.market_type,
+          quoteDelta,
+          trade.exchange_account
+        );
+      }
+    }
+
+    // Also include deposits - deposit = +qty, withdraw = -qty
+    let filteredDeposits = mockDeposits;
+    if (filters?.accountId) {
+      filteredDeposits = filteredDeposits.filter((d) => d.exchange_account_id === filters.accountId);
+    }
+
+    for (const deposit of filteredDeposits) {
+      if (deposit.asset === "USDC" || deposit.asset === "USDT") {
+        continue;
+      }
+      const qty = parseFloat(deposit.amount);
+      const delta = deposit.direction === "deposit" ? qty : -qty;
+      updateBalance(
+        deposit.asset,
+        deposit.exchange_account_id,
+        "spot",
+        delta,
+        deposit.exchange_account
+      );
+    }
+
+    // Apply filters
+    const assetsToInclude = filters?.baseAssets && filters.baseAssets.length > 0
+      ? new Set(filters.baseAssets)
+      : null;
+    const marketTypesToInclude = filters?.marketTypes && filters.marketTypes.length > 0
+      ? new Set(filters.marketTypes)
+      : null;
+
+    const openPositions: OpenPosition[] = [];
+
+    for (const [asset, accountMap] of assetBalances) {
+      if (assetsToInclude && !assetsToInclude.has(asset)) continue;
+
+      for (const [accountId, marketTypeMap] of accountMap) {
+        for (const [marketType, { netQty, account }] of marketTypeMap) {
+          if (marketTypesToInclude && !marketTypesToInclude.has(marketType as "perp" | "spot" | "swap")) continue;
+
+          if (Math.abs(netQty) > 0.0001) {
+            openPositions.push({
+              base_asset: asset,
+              quote_asset: "USD",
+              market_type: marketType as "perp" | "spot" | "swap",
+              side: netQty > 0 ? "long" : "short",
+              net_quantity: Math.abs(netQty),
+              avg_entry_price: 0,
+              total_cost: 0,
+              exchange_account_id: accountId,
+              exchange_account: account,
+            });
+          }
+        }
+      }
+    }
+
+    openPositions.sort((a, b) => b.net_quantity - a.net_quantity);
+    return openPositions;
   },
 };

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,4 +1,4 @@
-import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates, Position, PositionTrade, PositionsAggregates, Wallet, WalletWithAccounts } from "../queries";
+import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates, Position, PositionTrade, PositionsAggregates, Wallet, WalletWithAccounts, Deposit, DepositsAggregates, OpenPosition } from "../queries";
 
 export interface CreateAccountInput {
   exchange_id: string;
@@ -33,12 +33,17 @@ export interface PositionWithTrades extends Position {
   position_trades: PositionTrade[];
 }
 
+export interface DepositsResult {
+  deposits: Deposit[];
+  totalCount: number;
+}
+
 export interface DataFilters {
   accountId?: string;
   since?: number;
   until?: number;
   baseAssets?: string[];
-  marketTypes?: ("perp" | "spot")[];
+  marketTypes?: ("perp" | "spot" | "swap")[];
   tags?: string[];
 }
 
@@ -57,6 +62,10 @@ export interface ApiClient {
   getPositions(limit: number, offset: number, filters?: DataFilters): Promise<PositionsResult>;
   getPositionsAggregates(filters?: DataFilters): Promise<PositionsAggregates>;
   getPositionById(id: string): Promise<PositionWithTrades | null>;
+  // Deposit methods
+  getDeposits(limit: number, offset: number, filters?: DataFilters): Promise<DepositsResult>;
+  getDepositsAggregates(filters?: DataFilters): Promise<DepositsAggregates>;
+  getDistinctDepositAssets(): Promise<string[]>;
   // Wallet methods
   getWallets(): Promise<Wallet[]>;
   getWalletsWithCounts(): Promise<WalletWithAccounts[]>;
@@ -65,4 +74,6 @@ export interface ApiClient {
   updateAccountTags(id: string, tags: string[]): Promise<{ id: string; tags: string[] }>;
   updateWalletLabel(id: string, label: string | null): Promise<{ id: string; label: string | null }>;
   updateAccountLabel(id: string, label: string | null): Promise<{ id: string; label: string | null }>;
+  // Open positions (derived from trades)
+  getOpenPositions(filters?: DataFilters): Promise<OpenPosition[]>;
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -268,7 +268,7 @@ export interface Trade {
   order_id: string;
   trade_id: string;
   exchange_account_id: string;
-  market_type: "perp" | "spot";
+  market_type: "perp" | "spot" | "swap";
   exchange_account?: ExchangeAccount;
 }
 
@@ -1073,6 +1073,7 @@ export interface Position {
   base_asset: string;
   quote_asset: string;
   side: "long" | "short";
+  market_type: "perp" | "spot" | "swap";
   start_time: number; // Unix milliseconds (BIGINT)
   end_time: number; // Unix milliseconds (BIGINT)
   entry_avg_price: string;
@@ -1112,6 +1113,7 @@ export const GET_POSITIONS = gql`
       base_asset
       quote_asset
       side
+      market_type
       start_time
       end_time
       entry_avg_price
@@ -1141,6 +1143,7 @@ export const GET_POSITIONS_DYNAMIC = gql`
       base_asset
       quote_asset
       side
+      market_type
       start_time
       end_time
       entry_avg_price
@@ -1190,6 +1193,7 @@ export const GET_POSITION_WITH_TRADES = gql`
       base_asset
       quote_asset
       side
+      market_type
       start_time
       end_time
       entry_avg_price
@@ -1235,6 +1239,270 @@ export const GET_DISTINCT_POSITION_ASSETS = gql`
   query GetDistinctPositionAssets {
     positions(distinct_on: base_asset, order_by: { base_asset: asc }) {
       base_asset
+    }
+  }
+`;
+
+// Deposit types
+export interface Deposit {
+  id: string;
+  exchange_account_id: string;
+  asset: string;
+  direction: "deposit" | "withdraw";
+  amount: string;
+  user_cost_basis: string;
+  timestamp: number; // Unix milliseconds (BIGINT)
+  deposit_id: string;
+  exchange_account?: ExchangeAccount;
+}
+
+// Deposit aggregates interface
+export interface DepositsAggregates {
+  totalDeposits: string;
+  totalWithdrawals: string;
+  depositCount: number;
+  withdrawalCount: number;
+}
+
+// Deposit queries
+export const GET_DEPOSITS_DYNAMIC = gql`
+  query GetDepositsDynamic($limit: Int!, $offset: Int!, $where: deposits_bool_exp!) {
+    deposits(limit: $limit, offset: $offset, order_by: { timestamp: desc }, where: $where) {
+      id
+      exchange_account_id
+      asset
+      direction
+      amount
+      user_cost_basis
+      timestamp
+      deposit_id
+      exchange_account {
+        id
+        account_identifier
+        account_type
+        label
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+    deposits_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export const GET_DEPOSITS_AGGREGATES_DYNAMIC = gql`
+  query GetDepositsAggregatesDynamic($where: deposits_bool_exp!) {
+    deposits: deposits_aggregate(where: $where) {
+      aggregate {
+        count
+        sum {
+          amount
+        }
+      }
+    }
+    deposit_totals: deposits_aggregate(where: { _and: [$where, { direction: { _eq: "deposit" } }] }) {
+      aggregate {
+        count
+        sum {
+          amount
+        }
+      }
+    }
+    withdrawal_totals: deposits_aggregate(where: { _and: [$where, { direction: { _eq: "withdraw" } }] }) {
+      aggregate {
+        count
+        sum {
+          amount
+        }
+      }
+    }
+  }
+`;
+
+export const GET_DISTINCT_DEPOSIT_ASSETS = gql`
+  query GetDistinctDepositAssets {
+    deposits(distinct_on: asset, order_by: { asset: asc }) {
+      asset
+    }
+  }
+`;
+
+// Open Position types (derived from trades)
+export interface OpenPosition {
+  base_asset: string;
+  quote_asset: string;
+  market_type: "perp" | "spot" | "swap";
+  side: "long" | "short";
+  net_quantity: number;
+  avg_entry_price: number;
+  total_cost: number;
+  exchange_account_id?: string;
+  exchange_account?: ExchangeAccount;
+  // For spot positions traded against non-USD (e.g., bSOL/SOL)
+  native_quote_asset?: string; // The actual quote asset (e.g., "SOL" for bSOL/SOL)
+}
+
+// Query to get open positions by aggregating trades
+// This calculates net position = sum(buy quantities) - sum(sell quantities)
+export const GET_OPEN_POSITIONS = gql`
+  query GetOpenPositions {
+    perp_positions: trades(
+      where: { market_type: { _eq: "perp" } }
+      distinct_on: [base_asset, quote_asset, exchange_account_id]
+    ) {
+      base_asset
+      quote_asset
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        label
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+    spot_positions: trades(
+      where: { market_type: { _in: ["spot", "swap"] } }
+      distinct_on: [base_asset, quote_asset, exchange_account_id]
+    ) {
+      base_asset
+      quote_asset
+      exchange_account_id
+      exchange_account {
+        id
+        account_identifier
+        label
+        exchange {
+          id
+          name
+          display_name
+        }
+      }
+    }
+  }
+`;
+
+// Get trade totals for calculating open position quantities
+export const GET_TRADE_TOTALS_BY_ASSET = gql`
+  query GetTradeTotalsByAsset(
+    $base_asset: String!
+    $quote_asset: String!
+    $market_type: String!
+    $exchange_account_id: uuid!
+  ) {
+    buy_total: trades_aggregate(
+      where: {
+        base_asset: { _eq: $base_asset }
+        quote_asset: { _eq: $quote_asset }
+        market_type: { _eq: $market_type }
+        exchange_account_id: { _eq: $exchange_account_id }
+        side: { _eq: "buy" }
+      }
+    ) {
+      aggregate {
+        sum {
+          quantity
+        }
+        count
+      }
+    }
+    sell_total: trades_aggregate(
+      where: {
+        base_asset: { _eq: $base_asset }
+        quote_asset: { _eq: $quote_asset }
+        market_type: { _eq: $market_type }
+        exchange_account_id: { _eq: $exchange_account_id }
+        side: { _eq: "sell" }
+      }
+    ) {
+      aggregate {
+        sum {
+          quantity
+        }
+        count
+      }
+    }
+    # Get weighted average entry price (for the winning side)
+    buy_value: trades_aggregate(
+      where: {
+        base_asset: { _eq: $base_asset }
+        quote_asset: { _eq: $quote_asset }
+        market_type: { _eq: $market_type }
+        exchange_account_id: { _eq: $exchange_account_id }
+        side: { _eq: "buy" }
+      }
+    ) {
+      aggregate {
+        sum {
+          quantity
+        }
+      }
+    }
+    sell_value: trades_aggregate(
+      where: {
+        base_asset: { _eq: $base_asset }
+        quote_asset: { _eq: $quote_asset }
+        market_type: { _eq: $market_type }
+        exchange_account_id: { _eq: $exchange_account_id }
+        side: { _eq: "sell" }
+      }
+    ) {
+      aggregate {
+        sum {
+          quantity
+        }
+      }
+    }
+  }
+`;
+
+// Combined query for spot+swap positions
+export const GET_TRADE_TOTALS_SPOT_SWAP = gql`
+  query GetTradeTotalsSpotSwap(
+    $base_asset: String!
+    $quote_asset: String!
+    $exchange_account_id: uuid!
+  ) {
+    buy_total: trades_aggregate(
+      where: {
+        base_asset: { _eq: $base_asset }
+        quote_asset: { _eq: $quote_asset }
+        market_type: { _in: ["spot", "swap"] }
+        exchange_account_id: { _eq: $exchange_account_id }
+        side: { _eq: "buy" }
+      }
+    ) {
+      aggregate {
+        sum {
+          quantity
+        }
+        count
+      }
+    }
+    sell_total: trades_aggregate(
+      where: {
+        base_asset: { _eq: $base_asset }
+        quote_asset: { _eq: $quote_asset }
+        market_type: { _in: ["spot", "swap"] }
+        exchange_account_id: { _eq: $exchange_account_id }
+        side: { _eq: "sell" }
+      }
+    ) {
+      aggregate {
+        sum {
+          quantity
+        }
+        count
+      }
     }
   }
 `;


### PR DESCRIPTION
- Add deposits page with filtering by asset, date range, account
- Add deposits table component with direction badges
- Redesign open positions UI with split Perp/Spot sections
- Calculate and display entry prices from trade history
- Show spot holdings with native quote currency (e.g., bSOL cost in SOL)
- Display account info (exchange, label, tags) below asset name
- Add asset-based position tracking in API (tracks quote currency usage)
- Add native_quote_asset field to OpenPosition type
- Update market type filter to support positions filtering