### PR TITLE
Fix: redirect to login on expired token

### DIFF
--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -56,7 +56,10 @@ function isAuthError(error: unknown): boolean {
     if (response?.errors) {
       return response.errors.some(
         (e) => e.extensions?.code === "access-denied" ||
-               e.message === "no mutations exist"
+               e.message === "no mutations exist" ||
+               (e.extensions?.code === "validation-failed" &&
+                typeof e.message === "string" &&
+                e.message.includes("not found in type: 'query_root'"))
       );
     }
   }


### PR DESCRIPTION
## Summary
- When a token expires, Hasura falls back to the anonymous role which has no table access
- This produces `validation-failed` errors like `field 'wallets' not found in type: 'query_root'` instead of `access-denied`
- The existing `isAuthError()` check only looked for `access-denied`, so these errors were shown as raw GraphQL errors instead of redirecting to `/login`
- Now detects `validation-failed` + `not found in type: 'query_root'` as an auth error, clears the cookie, and redirects to login

## Test plan
- [ ] CI build passes
- [ ] With an expired/invalid token, navigating to `/accounts` redirects to `/login` instead of showing GraphQL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)