### PR TITLE
fix: move JWT token to HttpOnly cookie to prevent XSS theft

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const HASURA_URL = process.env.HASURA_URL || "http://167.99.145.4";
-const AUTH_URL = process.env.AUTH_URL || "http://167.99.145.4";
 const DISCOVERY_URL = process.env.DISCOVERY_URL || "http://localhost:8082";
 
 const nextConfig: NextConfig = {
@@ -9,14 +7,8 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
-        source: "/api/auth/:path*",
-        destination: `${AUTH_URL}/auth/:path*`,
-      },
-      {
-        source: "/api/graphql",
-        destination: `${HASURA_URL}/v1/graphql`,
-      },
-      {
+        // Auth and GraphQL routes are handled by API routes (HttpOnly cookie auth).
+        // Only discovery still uses a rewrite (no auth needed).
         source: "/api/discover/:path*",
         destination: `${DISCOVERY_URL}/:path*`,
       },

--- a/src/app/api/auth/[...path]/route.ts
+++ b/src/app/api/auth/[...path]/route.ts
@@ -1,0 +1,55 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
+
+const AUTH_URL = process.env.AUTH_URL || "http://localhost:8081";
+
+/**
+ * Catch-all proxy for auth service endpoints (wallet/challenge, wallet/verify, etc.).
+ * Injects the JWT token from the HttpOnly cookie as an Authorization header.
+ */
+async function proxyToAuth(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const subPath = path.join("/");
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
+
+  const headers: Record<string, string> = {};
+  const contentType = request.headers.get("content-type");
+  if (contentType) {
+    headers["Content-Type"] = contentType;
+  }
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const url = `${AUTH_URL}/auth/${subPath}`;
+
+  let authResponse: Response;
+  try {
+    authResponse = await fetch(url, {
+      method: request.method,
+      headers,
+      body: request.method !== "GET" ? await request.text() : undefined,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Unable to connect to auth service" },
+      { status: 502 }
+    );
+  }
+
+  const responseText = await authResponse.text();
+  return new NextResponse(responseText, {
+    status: authResponse.status,
+    headers: { "Content-Type": authResponse.headers.get("content-type") || "application/json" },
+  });
+}
+
+export const GET = proxyToAuth;
+export const POST = proxyToAuth;
+export const PUT = proxyToAuth;
+export const DELETE = proxyToAuth;

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,47 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
+
+const AUTH_URL = process.env.AUTH_URL || "http://localhost:8081";
+const IS_PRODUCTION = process.env.NODE_ENV === "production";
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+
+  let authResponse: Response;
+  try {
+    authResponse = await fetch(`${AUTH_URL}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Unable to connect to auth service" },
+      { status: 502 }
+    );
+  }
+
+  if (!authResponse.ok) {
+    const text = await authResponse.text();
+    return new NextResponse(text, {
+      status: authResponse.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const data = await authResponse.json();
+  const { token, expires_at } = data;
+
+  const cookieStore = await cookies();
+  cookieStore.set(TOKEN_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: IS_PRODUCTION,
+    sameSite: "lax",
+    expires: new Date(expires_at),
+    path: "/",
+  });
+
+  // Return success without the raw token — client doesn't need it
+  return NextResponse.json({ authenticated: true, expires_at });
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,25 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
+
+const AUTH_URL = process.env.AUTH_URL || "http://localhost:8081";
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
+
+  // Notify auth service to invalidate the token
+  if (token) {
+    try {
+      await fetch(`${AUTH_URL}/auth/logout`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch {
+      // Ignore — clear cookie regardless
+    }
+  }
+
+  cookieStore.delete(TOKEN_COOKIE_NAME);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,9 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
+  return NextResponse.json({ authenticated: !!token });
+}

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
+
+const HASURA_URL = process.env.HASURA_URL || "http://localhost:8080";
+
+export async function POST(request: NextRequest) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const body = await request.text();
+
+  let hasuraResponse: Response;
+  try {
+    hasuraResponse = await fetch(`${HASURA_URL}/v1/graphql`, {
+      method: "POST",
+      headers,
+      body,
+    });
+  } catch {
+    return NextResponse.json(
+      { errors: [{ message: "Unable to connect to GraphQL server" }] },
+      { status: 502 }
+    );
+  }
+
+  const data = await hasuraResponse.text();
+  return new NextResponse(data, {
+    status: hasuraResponse.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
-import { getToken, logout as authLogout, isAuthenticated } from "@/lib/auth";
+import { logout as authLogout, checkAuthStatus } from "@/lib/auth";
 
 export function useAuth() {
   const router = useRouter();
@@ -10,9 +10,10 @@ export function useAuth() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- required for initial auth check
-    setIsLoggedIn(isAuthenticated());
-    setIsLoading(false);
+    checkAuthStatus().then((authenticated) => {
+      setIsLoggedIn(authenticated);
+      setIsLoading(false);
+    });
   }, []);
 
   const logout = useCallback(async () => {
@@ -21,8 +22,8 @@ export function useAuth() {
     router.push("/login");
   }, [router]);
 
-  const checkAuth = useCallback(() => {
-    const authenticated = isAuthenticated();
+  const checkAuth = useCallback(async () => {
+    const authenticated = await checkAuthStatus();
     setIsLoggedIn(authenticated);
     return authenticated;
   }, []);
@@ -30,7 +31,6 @@ export function useAuth() {
   return {
     isLoggedIn,
     isLoading,
-    token: getToken(),
     logout,
     checkAuth,
   };

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -1,5 +1,4 @@
-import Cookies from "js-cookie";
-import { getGraphQLClient, TOKEN_COOKIE_NAME } from "../graphql-client";
+import { getGraphQLClient } from "../graphql-client";
 import {
   GET_EXCHANGES,
   GET_ACCOUNT_TYPES,
@@ -67,7 +66,8 @@ function isAuthError(error: unknown): boolean {
 }
 
 function handleAuthError(): never {
-  Cookies.remove(TOKEN_COOKIE_NAME);
+  // Clear HttpOnly cookie via server-side API route
+  fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
   if (typeof window !== "undefined") {
     window.location.href = "/login";
   }
@@ -598,8 +598,7 @@ export const graphqlApi: ApiClient = {
 
   // A2.1: Wallet ownership verification — challenge/response flow
   async requestWalletChallenge(address: string, chain: string): Promise<import("./types").WalletChallengeResponse> {
-    const authEndpoint = process.env.NEXT_PUBLIC_AUTH_ENDPOINT || "/api/auth";
-    const resp = await fetch(`${authEndpoint}/wallet/challenge`, {
+    const resp = await fetch("/api/auth/wallet/challenge", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ address, chain }),
@@ -617,14 +616,10 @@ export const graphqlApi: ApiClient = {
     signature: string,
     nonce: string,
   ): Promise<import("./types").WalletVerifyResponse> {
-    const authEndpoint = process.env.NEXT_PUBLIC_AUTH_ENDPOINT || "/api/auth";
-    const token = Cookies.get(TOKEN_COOKIE_NAME);
-    const resp = await fetch(`${authEndpoint}/wallet/verify`, {
+    // Auth catch-all API route injects the token from the HttpOnly cookie
+    const resp = await fetch("/api/auth/wallet/verify", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ address, chain, signature, nonce }),
     });
     if (!resp.ok) {
@@ -639,14 +634,10 @@ export const graphqlApi: ApiClient = {
     chain: string,
     apiKey: string,
   ): Promise<import("./types").WalletVerifyResponse> {
-    const authEndpoint = process.env.NEXT_PUBLIC_AUTH_ENDPOINT || "/api/auth";
-    const token = Cookies.get(TOKEN_COOKIE_NAME);
-    const resp = await fetch(`${authEndpoint}/wallet/verify-api-key`, {
+    // Auth catch-all API route injects the token from the HttpOnly cookie
+    const resp = await fetch("/api/auth/wallet/verify-api-key", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ address, chain, api_key: apiKey }),
     });
     if (!resp.ok) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,13 +1,5 @@
-import Cookies from "js-cookie";
-import { TOKEN_COOKIE_NAME } from "./graphql-client";
-
-// Auth endpoint - uses the Next.js rewrite proxy by default
-const AUTH_ENDPOINT = process.env.NEXT_PUBLIC_AUTH_ENDPOINT || "/api/auth";
-
-export interface LoginResponse {
-  token: string;
-  expires_at: string;
-}
+// Auth endpoint — calls our own API routes which manage HttpOnly cookies
+const AUTH_ENDPOINT = "/api/auth";
 
 export interface AuthError {
   message: string;
@@ -16,7 +8,7 @@ export interface AuthError {
 export async function login(
   username: string,
   password: string
-): Promise<LoginResponse> {
+): Promise<void> {
   let response: Response;
 
   try {
@@ -27,7 +19,7 @@ export async function login(
       },
       body: JSON.stringify({ username, password }),
     });
-  } catch (error) {
+  } catch {
     // Network error - server unreachable, CORS, etc.
     throw new Error(
       "Unable to connect to server. Please check your connection and try again."
@@ -50,41 +42,28 @@ export async function login(
     }
   }
 
-  const data: LoginResponse = await response.json();
-
-  // Store token in cookie
-  const expiresAt = new Date(data.expires_at);
-  Cookies.set(TOKEN_COOKIE_NAME, data.token, {
-    expires: expiresAt,
-    sameSite: "lax",
-  });
-
-  return data;
+  // Token is now stored in an HttpOnly cookie by the API route — no client-side storage needed
 }
 
 export async function logout(): Promise<void> {
-  const token = Cookies.get(TOKEN_COOKIE_NAME);
-
-  if (token) {
-    try {
-      await fetch(`${AUTH_ENDPOINT}/logout`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-    } catch {
-      // Ignore logout errors - we'll clear the cookie anyway
-    }
+  try {
+    await fetch(`${AUTH_ENDPOINT}/logout`, {
+      method: "POST",
+    });
+  } catch {
+    // Ignore logout errors
   }
-
-  Cookies.remove(TOKEN_COOKIE_NAME);
 }
 
-export function getToken(): string | undefined {
-  return Cookies.get(TOKEN_COOKIE_NAME);
-}
-
-export function isAuthenticated(): boolean {
-  return !!getToken();
+/**
+ * Check auth status via server-side API route (cannot read HttpOnly cookie directly).
+ */
+export async function checkAuthStatus(): Promise<boolean> {
+  try {
+    const response = await fetch(`${AUTH_ENDPOINT}/me`);
+    const data = await response.json();
+    return data.authenticated === true;
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/cookie-config.ts
+++ b/src/lib/cookie-config.ts
@@ -1,0 +1,2 @@
+const COOKIE_SUFFIX = process.env.NEXT_PUBLIC_COOKIE_SUFFIX || "";
+export const TOKEN_COOKIE_NAME = `zif_auth_token${COOKIE_SUFFIX}`;

--- a/src/lib/graphql-client.ts
+++ b/src/lib/graphql-client.ts
@@ -1,9 +1,4 @@
 import { GraphQLClient } from "graphql-request";
-import Cookies from "js-cookie";
-
-// Cookie name can be customized via env var to allow multiple instances on same host
-const COOKIE_SUFFIX = process.env.NEXT_PUBLIC_COOKIE_SUFFIX || "";
-export const TOKEN_COOKIE_NAME = `zif_auth_token${COOKIE_SUFFIX}`;
 
 function getGraphQLEndpoint(): string {
   const endpoint =
@@ -17,22 +12,11 @@ function getGraphQLEndpoint(): string {
   return endpoint;
 }
 
+/**
+ * Returns a GraphQL client that posts to our API proxy route.
+ * The proxy reads the HttpOnly auth cookie server-side and injects
+ * the Authorization header — no client-side token handling needed.
+ */
 export function getGraphQLClient(): GraphQLClient {
-  const token = Cookies.get(TOKEN_COOKIE_NAME);
-
-  return new GraphQLClient(getGraphQLEndpoint(), {
-    headers: token
-      ? {
-          Authorization: `Bearer ${token}`,
-        }
-      : {},
-  });
-}
-
-export function getAuthenticatedClient(token: string): GraphQLClient {
-  return new GraphQLClient(getGraphQLEndpoint(), {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  return new GraphQLClient(getGraphQLEndpoint());
 }


### PR DESCRIPTION
## Summary
- Moves JWT token storage from client-side `js-cookie` to server-managed **HttpOnly cookies** via Next.js API routes
- Token is no longer accessible to JavaScript — `document.cookie` cannot read it, preventing exfiltration via XSS
- Cookie includes `secure` flag (production), `sameSite: lax`, and `path: /`

## Architecture

**Before:** Client stores token in js-cookie → reads it for every GraphQL request → any XSS can steal it via `document.cookie`

**After:** Server-side API routes manage the token in an HttpOnly cookie that JavaScript cannot access:

| Route | Purpose |
|-------|---------|
| `POST /api/auth/login` | Proxies to auth service, sets HttpOnly cookie |
| `POST /api/auth/logout` | Clears HttpOnly cookie, notifies auth service |
| `GET /api/auth/me` | Returns auth status (cookie check server-side) |
| `/api/auth/[...path]` | Catch-all proxy for wallet verification — injects token |
| `POST /api/graphql` | GraphQL proxy — reads cookie, adds Authorization header |

## Files Changed
- **New:** 5 API routes + `cookie-config.ts` (shared constant)
- **Modified:** `auth.ts`, `graphql-client.ts`, `graphql.ts` (removed js-cookie), `use-auth.ts` (async auth check), `next.config.ts` (removed rewrites replaced by API routes)
- **Unchanged:** `middleware.ts` (already reads cookies server-side), `login-form.tsx`

Closes #39

## Test plan
- [x] `next build` succeeds (0 TypeScript errors)
- [x] `eslint` passes (0 new warnings)
- [ ] Manual test: login → verify token NOT visible in `document.cookie`
- [ ] Manual test: GraphQL requests work (proxied through API route)
- [ ] Manual test: logout clears HttpOnly cookie
- [ ] Manual test: wallet verification still works (catch-all proxy)
- [ ] Manual test: expired token triggers redirect to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)