### PR TITLE
feat: add sync status indicators for data freshness

### DIFF
--- a/src/app/(dashboard)/portfolio/page.tsx
+++ b/src/app/(dashboard)/portfolio/page.tsx
@@ -26,6 +26,7 @@ import { ExchangeBadge } from "@/components/exchange-badge";
 import { useGlobalTags } from "@/contexts/filters-context";
 import { cn } from "@/lib/utils";
 import { formatNumber, formatTimestamp, getDisplayName } from "@/lib/format";
+import { DataFreshnessBadge } from "@/components/data-freshness-badge";
 
 const CLOSED_PAGE_SIZE = 50;
 
@@ -219,11 +220,14 @@ export default function PortfolioPage() {
         title="Portfolio"
         description="Current positions and closed position history"
         action={
-          <SyncButton
-            lastRefreshTime={lastRefreshTime}
-            onRefresh={refresh}
-            isLoading={isLoadingOpen || isLoadingClosed}
-          />
+          <div className="flex items-center gap-3">
+            <DataFreshnessBadge accounts={accounts} />
+            <SyncButton
+              lastRefreshTime={lastRefreshTime}
+              onRefresh={refresh}
+              isLoading={isLoadingOpen || isLoadingClosed}
+            />
+          </div>
         }
       />
 

--- a/src/components/accounts-table.tsx
+++ b/src/components/accounts-table.tsx
@@ -6,10 +6,10 @@ import { toast } from "sonner";
 import { Lock } from "lucide-react";
 import { api } from "@/lib/api";
 import { ExchangeAccount } from "@/lib/queries";
-import { normalizeTags } from "@/lib/utils";
+import { normalizeTags, cn } from "@/lib/utils";
 import { useApi } from "@/hooks/use-api";
 import { useGlobalTags } from "@/contexts/filters-context";
-import { formatRelativeTime } from "@/lib/format";
+import { formatRelativeTime, getSyncFreshness, getSyncFreshnessColor, getSyncFreshnessLabel } from "@/lib/format";
 import {
   Table,
   TableBody,
@@ -65,6 +65,33 @@ function ApiKeyLockedBadge() {
   );
 }
 
+function SyncStatusCell({ lastSyncedAt }: { lastSyncedAt: string | null | undefined }) {
+  const freshness = getSyncFreshness(lastSyncedAt);
+  const colorClass = getSyncFreshnessColor(freshness);
+  const label = getSyncFreshnessLabel(freshness);
+  const relativeTime = formatRelativeTime(lastSyncedAt);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn("text-sm inline-flex items-center gap-1.5", colorClass)}>
+          <span className={cn(
+            "inline-block w-1.5 h-1.5 rounded-full flex-shrink-0",
+            freshness === "fresh" && "bg-green-500",
+            freshness === "ok" && "bg-muted-foreground",
+            freshness === "stale" && "bg-yellow-500",
+            (freshness === "very-stale" || freshness === "never") && "bg-red-500",
+          )} />
+          {relativeTime}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p className="text-xs">{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function getStatusBadge(status: string | undefined) {
   if (!status || status === "active") return null;
   if (status === "needs_token") {
@@ -90,6 +117,13 @@ export function AccountsTable({ refreshKey, onLoadingChange, onRefreshComplete }
   const { globalTags: selectedTags, refreshTags } = useGlobalTags();
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  // Tick every 60s to refresh relative timestamps and freshness indicators
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(interval);
+  }, []);
 
   const fetchAccounts = async () => {
     setIsLoading(true);
@@ -207,6 +241,8 @@ export function AccountsTable({ refreshKey, onLoadingChange, onRefreshComplete }
               <TableHead>Label / Account</TableHead>
               <TableHead>Type</TableHead>
               <TableHead>Tags</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Last Synced</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -240,6 +276,12 @@ export function AccountsTable({ refreshKey, onLoadingChange, onRefreshComplete }
                     onTagsChange={(tags) => handleTagsChange(account.id, tags)}
                     availableTags={allAccountTags}
                   />
+                </TableCell>
+                <TableCell>
+                  {getStatusBadge(account.status)}
+                </TableCell>
+                <TableCell>
+                  <SyncStatusCell lastSyncedAt={account.last_synced_at} />
                 </TableCell>
               </TableRow>
             ))}
@@ -324,8 +366,8 @@ export function AccountsTable({ refreshKey, onLoadingChange, onRefreshComplete }
                     <TableCell>
                       {getStatusBadge(account.status)}
                     </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {formatRelativeTime(account.last_synced_at)}
+                    <TableCell>
+                      <SyncStatusCell lastSyncedAt={account.last_synced_at} />
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/components/data-freshness-badge.tsx
+++ b/src/components/data-freshness-badge.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { AlertTriangle } from "lucide-react";
+import { ExchangeAccount } from "@/lib/queries";
+import {
+  formatRelativeTime,
+  getSyncFreshness,
+  getSyncFreshnessColor,
+  getSyncFreshnessLabel,
+  SyncFreshness,
+} from "@/lib/format";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface DataFreshnessBadgeProps {
+  accounts: ExchangeAccount[];
+}
+
+/** Shows the overall data freshness based on the oldest last_synced_at across accounts. */
+export function DataFreshnessBadge({ accounts }: DataFreshnessBadgeProps) {
+  // Tick every 60s to keep relative time current
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const { oldestTimestamp, freshness, staleCount } = useMemo(() => {
+    if (accounts.length === 0) {
+      return { oldestTimestamp: null, freshness: "never" as SyncFreshness, staleCount: 0 };
+    }
+
+    let oldest: string | null = null;
+    let oldestMs = Infinity;
+    let stale = 0;
+
+    for (const account of accounts) {
+      const ts = account.last_synced_at;
+      if (!ts) {
+        oldest = null;
+        oldestMs = -Infinity;
+        stale++;
+        continue;
+      }
+      const ms = new Date(ts).getTime();
+      if (ms < oldestMs) {
+        oldestMs = ms;
+        oldest = ts;
+      }
+      const f = getSyncFreshness(ts);
+      if (f === "stale" || f === "very-stale" || f === "never") {
+        stale++;
+      }
+    }
+
+    // If any account never synced, that's the worst case
+    if (oldestMs === -Infinity) {
+      return { oldestTimestamp: null, freshness: "never" as SyncFreshness, staleCount: stale };
+    }
+
+    return {
+      oldestTimestamp: oldest,
+      freshness: getSyncFreshness(oldest),
+      staleCount: stale,
+    };
+  }, [accounts]);
+
+  if (accounts.length === 0) return null;
+
+  const colorClass = getSyncFreshnessColor(freshness);
+  const label = getSyncFreshnessLabel(freshness);
+  const hasWarning = freshness === "stale" || freshness === "very-stale" || freshness === "never";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn("text-xs inline-flex items-center gap-1.5", colorClass)}>
+          {hasWarning && <AlertTriangle className="h-3 w-3" />}
+          <span>Data {oldestTimestamp ? formatRelativeTime(oldestTimestamp) : "never synced"}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <p className="text-xs font-medium">{label}</p>
+        {staleCount > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {staleCount} account{staleCount !== 1 ? "s" : ""} with stale data
+          </p>
+        )}
+        {oldestTimestamp && (
+          <p className="text-xs text-muted-foreground">
+            Oldest sync: {new Date(oldestTimestamp).toLocaleString()}
+          </p>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -57,6 +57,44 @@ export function formatRelativeTime(timestamp: string | number | null | undefined
   return date.toLocaleDateString();
 }
 
+export type SyncFreshness = "fresh" | "ok" | "stale" | "very-stale" | "never";
+
+/** Classify how fresh a last_synced_at timestamp is. */
+export function getSyncFreshness(timestamp: string | number | null | undefined): SyncFreshness {
+  if (!timestamp) return "never";
+
+  const date = parseTimestamp(timestamp);
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = diffMs / 60_000;
+
+  if (diffMin < 15) return "fresh";
+  if (diffMin < 60) return "ok";
+  if (diffMin < 360) return "stale";
+  return "very-stale";
+}
+
+/** Get Tailwind text color class for a sync freshness level. */
+export function getSyncFreshnessColor(freshness: SyncFreshness): string {
+  switch (freshness) {
+    case "fresh": return "text-green-600 dark:text-green-400";
+    case "ok": return "text-muted-foreground";
+    case "stale": return "text-yellow-600 dark:text-yellow-400";
+    case "very-stale": return "text-red-600 dark:text-red-400";
+    case "never": return "text-red-600 dark:text-red-400";
+  }
+}
+
+/** Human-readable label for sync freshness. */
+export function getSyncFreshnessLabel(freshness: SyncFreshness): string {
+  switch (freshness) {
+    case "fresh": return "Fresh";
+    case "ok": return "OK";
+    case "stale": return "Stale";
+    case "very-stale": return "Very stale";
+    case "never": return "Never synced";
+  }
+}
+
 export function truncateAddress(address: string, startChars = 6, endChars = 4): string {
   if (address.length <= startChars + endChars + 3) return address;
   return `${address.slice(0, startChars)}...${address.slice(-endChars)}`;


### PR DESCRIPTION
## Summary
- Add colored freshness indicators to the accounts table showing when each account was last synced
- Add a data freshness badge to the portfolio page header showing overall staleness
- Indicators use dot + color coding: green (fresh, <15min), default (OK, <1hr), yellow (stale, 1-6hr), red (very stale, >6hr or never)
- Auto-refresh every 60 seconds without page reload
- Tooltip shows freshness label; portfolio badge shows stale account count

## Changes
- `src/lib/format.ts` — Add `getSyncFreshness()`, `getSyncFreshnessColor()`, `getSyncFreshnessLabel()` utilities
- `src/components/accounts-table.tsx` — Add `SyncStatusCell` with colored dot + relative time in both simple and grouped table views; add 60s tick for auto-refresh
- `src/components/data-freshness-badge.tsx` — New component showing oldest sync time across accounts with warning icon when stale
- `src/app/(dashboard)/portfolio/page.tsx` — Add `DataFreshnessBadge` next to the sync button in page header

## Test plan
- [x] `next build` passes with no TypeScript errors
- [ ] Verify accounts table shows colored sync status in both simple (no wallets) and grouped views
- [ ] Verify "Never synced" shows in red for accounts with null `last_synced_at`
- [ ] Verify portfolio page shows overall freshness badge with warning when any account is stale
- [ ] Verify relative times update every 60s without manual refresh
- [ ] Verify mobile responsiveness

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)