### PR TITLE
fix: enforce auth on all API routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,19 +1,9 @@
 import type { NextConfig } from "next";
 
-const DISCOVERY_URL = process.env.DISCOVERY_URL || "http://localhost:8082";
-
 const nextConfig: NextConfig = {
   output: "standalone",
-  async rewrites() {
-    return [
-      {
-        // Auth and GraphQL routes are handled by API routes (HttpOnly cookie auth).
-        // Only discovery still uses a rewrite (no auth needed).
-        source: "/api/discover/:path*",
-        destination: `${DISCOVERY_URL}/:path*`,
-      },
-    ];
-  },
+  // Discovery proxy moved to API route (src/app/api/discover/[...path]/route.ts)
+  // to enforce auth. No rewrites needed.
 };
 
 export default nextConfig;

--- a/src/app/api/auth/[...path]/route.ts
+++ b/src/app/api/auth/[...path]/route.ts
@@ -4,16 +4,24 @@ import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
 
 const AUTH_URL = process.env.AUTH_URL || "http://localhost:8081";
 
-/**
- * Catch-all proxy for auth service endpoints (wallet/challenge, wallet/verify, etc.).
- * Injects the JWT token from the HttpOnly cookie as an Authorization header.
- */
-async function proxyToAuth(
+// Only these auth service paths are proxied. All are POST-only.
+const ALLOWED_PATHS = new Set([
+  "wallet/challenge",
+  "wallet/verify",
+  "wallet/verify-api-key",
+]);
+
+export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ path: string[] }> }
 ) {
   const { path } = await params;
   const subPath = path.join("/");
+
+  if (!ALLOWED_PATHS.has(subPath)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
   const cookieStore = await cookies();
   const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
 
@@ -26,14 +34,12 @@ async function proxyToAuth(
     headers["Authorization"] = `Bearer ${token}`;
   }
 
-  const url = `${AUTH_URL}/auth/${subPath}`;
-
   let authResponse: Response;
   try {
-    authResponse = await fetch(url, {
-      method: request.method,
+    authResponse = await fetch(`${AUTH_URL}/auth/${subPath}`, {
+      method: "POST",
       headers,
-      body: request.method !== "GET" ? await request.text() : undefined,
+      body: await request.text(),
     });
   } catch {
     return NextResponse.json(
@@ -45,11 +51,9 @@ async function proxyToAuth(
   const responseText = await authResponse.text();
   return new NextResponse(responseText, {
     status: authResponse.status,
-    headers: { "Content-Type": authResponse.headers.get("content-type") || "application/json" },
+    headers: {
+      "Content-Type":
+        authResponse.headers.get("content-type") || "application/json",
+    },
   });
 }
-
-export const GET = proxyToAuth;
-export const POST = proxyToAuth;
-export const PUT = proxyToAuth;
-export const DELETE = proxyToAuth;

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -2,8 +2,32 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
 
+const AUTH_URL = process.env.AUTH_URL || "http://localhost:8081";
+
 export async function GET() {
   const cookieStore = await cookies();
   const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
-  return NextResponse.json({ authenticated: !!token });
+
+  if (!token) {
+    return NextResponse.json({ authenticated: false });
+  }
+
+  // Validate token against the auth service webhook
+  try {
+    const webhookResponse = await fetch(`${AUTH_URL}/auth/webhook`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!webhookResponse.ok) {
+      // Token is expired or invalid — clear the stale cookie
+      cookieStore.delete(TOKEN_COOKIE_NAME);
+      return NextResponse.json({ authenticated: false });
+    }
+
+    return NextResponse.json({ authenticated: true });
+  } catch {
+    // Auth service unreachable — report unauthenticated to be safe
+    return NextResponse.json({ authenticated: false });
+  }
 }

--- a/src/app/api/discover/[...path]/route.ts
+++ b/src/app/api/discover/[...path]/route.ts
@@ -1,0 +1,69 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
+
+const AUTH_URL = process.env.AUTH_URL || "http://localhost:8081";
+const DISCOVERY_URL = process.env.DISCOVERY_URL || "http://localhost:8082";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return NextResponse.json(
+      { error: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  // Validate token against the auth service
+  let webhookResponse: Response;
+  try {
+    webhookResponse = await fetch(`${AUTH_URL}/auth/webhook`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Unable to validate authentication" },
+      { status: 502 }
+    );
+  }
+
+  if (!webhookResponse.ok) {
+    return NextResponse.json(
+      { error: "Authentication expired or invalid" },
+      { status: 401 }
+    );
+  }
+
+  const { path } = await params;
+  const subPath = path.join("/");
+  const body = await request.text();
+
+  let discoveryResponse: Response;
+  try {
+    discoveryResponse = await fetch(`${DISCOVERY_URL}/${subPath}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Unable to connect to discovery service" },
+      { status: 502 }
+    );
+  }
+
+  const responseText = await discoveryResponse.text();
+  return new NextResponse(responseText, {
+    status: discoveryResponse.status,
+    headers: {
+      "Content-Type":
+        discoveryResponse.headers.get("content-type") || "application/json",
+    },
+  });
+}

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -8,11 +8,11 @@ export async function POST(request: NextRequest) {
   const cookieStore = await cookies();
   const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  if (token) {
-    headers["Authorization"] = `Bearer ${token}`;
+  if (!token) {
+    return NextResponse.json(
+      { errors: [{ message: "Authentication required" }] },
+      { status: 401 }
+    );
   }
 
   const body = await request.text();
@@ -21,7 +21,10 @@ export async function POST(request: NextRequest) {
   try {
     hasuraResponse = await fetch(`${HASURA_URL}/v1/graphql`, {
       method: "POST",
-      headers,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
       body,
     });
   } catch {


### PR DESCRIPTION
## Summary

Fixes all four unauthenticated API route bypasses identified in #41:

- **GraphQL proxy** (`/api/graphql`): Now rejects requests without an auth token with 401, instead of forwarding unauthenticated requests to Hasura
- **Discovery proxy** (`/api/discover/*`): Replaced the unauthenticated `next.config.ts` rewrite with a new authenticated API route that validates the token against the auth service before proxying
- **Auth `/me` endpoint** (`/api/auth/me`): Now validates the token against the auth service webhook instead of just checking cookie existence. Clears stale cookies when token is invalid
- **Auth catch-all proxy** (`/api/auth/[...path]`): Restricted from all HTTP methods on any path to POST-only on an allowlist of wallet endpoints (`wallet/challenge`, `wallet/verify`, `wallet/verify-api-key`). Removed GET/PUT/DELETE exports

## Test plan

- [ ] Login flow still works (cookie set, redirected to dashboard)
- [ ] GraphQL queries succeed when authenticated
- [ ] GraphQL proxy returns 401 when unauthenticated (clear cookie, hit `/api/graphql`)
- [ ] Discovery endpoint returns 401 when unauthenticated
- [ ] `/api/auth/me` returns `{authenticated: true}` with valid token
- [ ] `/api/auth/me` returns `{authenticated: false}` with expired/invalid token
- [ ] Wallet challenge/verify endpoints still work through the proxy
- [ ] Non-allowlisted auth paths return 404 (e.g. `/api/auth/webhook`)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)