### PR TITLE
fix: auth cookie cleared on navigation due to webhook method mismatch

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -15,8 +15,11 @@ export async function GET() {
   // Validate token against the auth service webhook
   try {
     const webhookResponse = await fetch(`${AUTH_URL}/auth/webhook`, {
-      method: "GET",
-      headers: { Authorization: `Bearer ${token}` },
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
     });
 
     if (!webhookResponse.ok) {


### PR DESCRIPTION
## Summary
- `/api/auth/me` was sending GET requests to the auth webhook, but the webhook only accepts POST
- The webhook returned 405 (Method Not Allowed), which the handler misinterpreted as "invalid token" and **deleted the auth cookie**
- `/accounts` worked by coincidence — its GraphQL requests fired concurrently with the auth check, using the cookie before deletion
- All other pages (`/portfolio`, `/trades`, `/funding`, `/transfers`) failed because by the time the user navigated, the cookie was already gone

## Fix
Changed the webhook validation call in `/api/auth/me/route.ts` from `GET` to `POST` with proper `Content-Type` header.

## Test plan
- [ ] Log in to the dashboard
- [ ] Navigate to /accounts — verify it works
- [ ] Navigate to /portfolio — verify it stays authenticated (was redirecting to /login)
- [ ] Navigate to /trades, /funding, /transfers — verify all stay authenticated
- [ ] Refresh any page — verify cookie persists
- [ ] Log out and verify redirect to /login

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)