### PR TITLE
fix: show error toast when login is rate-limited (429)

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,16 +30,22 @@ export async function login(
     if (response.status === 401) {
       throw new Error("Invalid username or password");
     }
+    if (response.status === 429) {
+      throw new Error(
+        "Too many login attempts. Please wait a minute and try again."
+      );
+    }
     if (response.status === 500) {
       throw new Error("Server error. Please try again later.");
     }
     // Try to get error message from response body
+    let text: string | undefined;
     try {
-      const text = await response.text();
-      throw new Error(text || `Login failed (${response.status})`);
+      text = await response.text();
     } catch {
-      throw new Error(`Login failed (${response.status})`);
+      // ignore body read failure
     }
+    throw new Error(text || `Login failed (${response.status})`);
   }
 
   // Token is now stored in an HttpOnly cookie by the API route — no client-side storage needed


### PR DESCRIPTION
## Summary
- Add explicit 429 status handler in `login()` — shows "Too many login attempts. Please wait a minute and try again." via toast
- Fix broken try/catch pattern where `throw new Error(text)` was caught by its own catch block, silently discarding the server's error message for all non-401/500 status codes

## What changed
- `src/lib/auth.ts` — added 429 handler, restructured generic error fallback to read body separately then throw once

## Root cause
The original code had:
```ts
try {
  const text = await response.text();
  throw new Error(text);      // ← this throw...
} catch {
  throw new Error("generic"); // ← ...was caught here
}
```
So the server's "Too many login attempts" message was always discarded.

Closes #57

## Test plan
- [x] `next build` passes
- [ ] Manual: trigger rate limit (3 rapid logins) → verify toast shows rate-limit message
- [ ] Manual: bad password → verify "Invalid username or password" still works
- [ ] Manual: server down → verify "Unable to connect" still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)