### PR TITLE
fix: set auth cookies on response object to fix login redirect

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,4 +1,3 @@
-import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
 
@@ -33,8 +32,11 @@ export async function POST(request: NextRequest) {
   const data = await authResponse.json();
   const { token, expires_at } = data;
 
-  const cookieStore = await cookies();
-  cookieStore.set(TOKEN_COOKIE_NAME, token, {
+  // Set cookie directly on the response object to ensure the Set-Cookie
+  // header is included. Using (await cookies()).set() can fail to propagate
+  // when a separate NextResponse is returned.
+  const response = NextResponse.json({ authenticated: true, expires_at });
+  response.cookies.set(TOKEN_COOKIE_NAME, token, {
     httpOnly: true,
     secure: IS_PRODUCTION,
     sameSite: "lax",
@@ -42,6 +44,5 @@ export async function POST(request: NextRequest) {
     path: "/",
   });
 
-  // Return success without the raw token — client doesn't need it
-  return NextResponse.json({ authenticated: true, expires_at });
+  return response;
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -20,6 +20,9 @@ export async function POST() {
     }
   }
 
-  cookieStore.delete(TOKEN_COOKIE_NAME);
-  return NextResponse.json({ success: true });
+  // Delete cookie on the response object to ensure the Set-Cookie header
+  // is included in the actual response sent to the browser.
+  const response = NextResponse.json({ success: true });
+  response.cookies.delete(TOKEN_COOKIE_NAME);
+  return response;
 }

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -24,8 +24,9 @@ export async function GET() {
 
     if (!webhookResponse.ok) {
       // Token is expired or invalid — clear the stale cookie
-      cookieStore.delete(TOKEN_COOKIE_NAME);
-      return NextResponse.json({ authenticated: false });
+      const response = NextResponse.json({ authenticated: false });
+      response.cookies.delete(TOKEN_COOKIE_NAME);
+      return response;
     }
 
     return NextResponse.json({ authenticated: true });

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -49,6 +49,7 @@ export function LoginForm() {
     try {
       await login(data.username, data.password);
       toast.success("Logged in successfully");
+      router.refresh();
       router.push("/accounts");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Login failed");


### PR DESCRIPTION
## Summary
- Login redirect was broken because `(await cookies()).set()` in Next.js 16 route handlers doesn't always propagate the `Set-Cookie` header when a separate `NextResponse` is returned
- The browser never received the auth cookie, so middleware redirected back to `/login` after `router.push("/accounts")`
- Fixed all three auth routes (login, logout, me) to set/delete cookies directly on the `NextResponse` object
- Added `router.refresh()` before `router.push()` in the login form to invalidate the router cache

## Changes
- `src/app/api/auth/login/route.ts` — Set cookie on `response.cookies.set()` instead of `cookieStore.set()`
- `src/app/api/auth/logout/route.ts` — Delete cookie on `response.cookies.delete()` instead of `cookieStore.delete()`
- `src/app/api/auth/me/route.ts` — Delete stale cookie on response object when token is invalid
- `src/components/login-form.tsx` — Add `router.refresh()` before `router.push("/accounts")`

## Test plan
- [ ] Login with valid credentials → should redirect to /accounts
- [ ] Logout → should redirect to /login and clear cookie
- [ ] Visit /accounts without auth → should redirect to /login
- [ ] Login with invalid credentials → should show error toast
- [ ] Verify `next build` succeeds (confirmed locally)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)