### PR TITLE
feat: user registration page with signup form

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
+
+const AUTH_URL = process.env.AUTH_URL || "http://localhost:8081";
+const IS_PRODUCTION = process.env.NODE_ENV === "production";
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+
+  let authResponse: Response;
+  try {
+    authResponse = await fetch(`${AUTH_URL}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Unable to connect to auth service" },
+      { status: 502 }
+    );
+  }
+
+  if (!authResponse.ok) {
+    const text = await authResponse.text();
+    return new NextResponse(text, {
+      status: authResponse.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const data = await authResponse.json();
+  const { token, expires_at, user } = data;
+
+  // Set auth cookie same as login — registration auto-logs in
+  const response = NextResponse.json({
+    authenticated: true,
+    expires_at,
+    user,
+  });
+  response.cookies.set(TOKEN_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: IS_PRODUCTION,
+    sameSite: "lax",
+    expires: new Date(expires_at),
+    path: "/",
+  });
+
+  return response;
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,9 @@
+import { SignupForm } from "@/components/signup-form";
+
+export default function SignupPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-background p-4">
+      <SignupForm />
+    </main>
+  );
+}

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { toast } from "sonner";
 import { login } from "@/lib/auth";
 import { LoadingButton } from "@/components/ui/loading-button";
+import Link from "next/link";
 import { Input } from "@/components/ui/input";
 import {
   Form,
@@ -104,6 +105,12 @@ export function LoginForm() {
             </LoadingButton>
           </form>
         </Form>
+        <p className="mt-4 text-center text-sm text-muted-foreground">
+          Don&apos;t have an account?{" "}
+          <Link href="/signup" className="text-primary underline-offset-4 hover:underline">
+            Sign up
+          </Link>
+        </p>
       </CardContent>
     </Card>
   );

--- a/src/components/signup-form.tsx
+++ b/src/components/signup-form.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { signup } from "@/lib/auth";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import Link from "next/link";
+
+const signupSchema = z
+  .object({
+    email: z.string().email("Please enter a valid email address"),
+    username: z
+      .string()
+      .optional()
+      .refine((val) => !val || val.length >= 3, {
+        message: "Username must be at least 3 characters",
+      }),
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+type SignupFormValues = z.infer<typeof signupSchema>;
+
+export function SignupForm() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const form = useForm<SignupFormValues>({
+    resolver: zodResolver(signupSchema),
+    defaultValues: {
+      email: "",
+      username: "",
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  async function onSubmit(data: SignupFormValues) {
+    setIsLoading(true);
+    try {
+      await signup(data.email, data.password, data.username || undefined);
+      toast.success("Account created successfully");
+      router.refresh();
+      router.push("/accounts");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Registration failed"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-2xl font-bold">Create an account</CardTitle>
+        <CardDescription>
+          Enter your details to get started with ZIF Terminal
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="you@example.com"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="username"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Username (optional)</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Choose a username" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder="At least 8 characters"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Confirm Password</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder="Repeat your password"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <LoadingButton
+              type="submit"
+              className="w-full"
+              loading={isLoading}
+            >
+              Create account
+            </LoadingButton>
+          </form>
+        </Form>
+        <p className="mt-4 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link href="/login" className="text-primary underline-offset-4 hover:underline">
+            Sign in
+          </Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -51,6 +51,61 @@ export async function login(
   // Token is now stored in an HttpOnly cookie by the API route — no client-side storage needed
 }
 
+export async function signup(
+  email: string,
+  password: string,
+  username?: string
+): Promise<void> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${AUTH_ENDPOINT}/register`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, password, username }),
+    });
+  } catch {
+    throw new Error(
+      "Unable to connect to server. Please check your connection and try again."
+    );
+  }
+
+  if (!response.ok) {
+    if (response.status === 409) {
+      let text: string | undefined;
+      try {
+        text = await response.text();
+      } catch {
+        // ignore
+      }
+      throw new Error(text?.trim() || "Email or username already taken");
+    }
+    if (response.status === 400) {
+      let text: string | undefined;
+      try {
+        text = await response.text();
+      } catch {
+        // ignore
+      }
+      throw new Error(text?.trim() || "Invalid registration details");
+    }
+    if (response.status === 500) {
+      throw new Error("Server error. Please try again later.");
+    }
+    let text: string | undefined;
+    try {
+      text = await response.text();
+    } catch {
+      // ignore
+    }
+    throw new Error(text || `Registration failed (${response.status})`);
+  }
+
+  // Token is now stored in an HttpOnly cookie by the API route
+}
+
 export async function logout(): Promise<void> {
   try {
     await fetch(`${AUTH_ENDPOINT}/logout`, {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,8 +6,8 @@ const COOKIE_SUFFIX = process.env.NEXT_PUBLIC_COOKIE_SUFFIX || "";
 const TOKEN_COOKIE_NAME = `zif_auth_token${COOKIE_SUFFIX}`;
 
 // Paths that should redirect to the dashboard when the user is already logged in.
-// Only /login qualifies: there is no point showing the login form to a logged-in user.
-const authRedirectPaths = ["/login"];
+// /login and /signup: no point showing auth forms to a logged-in user.
+const authRedirectPaths = ["/login", "/signup"];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
## Summary
- Adds **/signup page** with registration form: email, optional username, password with confirmation
- Adds **/api/auth/register** route handler that proxies to the backend auth service (POST /auth/register from auth#4) and sets HttpOnly auth cookie — users are auto-logged-in after signup
- Adds **signup()** client function in `lib/auth.ts` with proper error handling (409 for duplicate email/username, 400 for validation errors)
- Adds **"Sign up" link** on login page and **"Sign in" link** on signup page for navigation between auth flows
- Updates **middleware** to treat `/signup` as an auth-redirect path (logged-in users skip to dashboard)

Partial progress on #47 — enables the user registration flow that's a prerequisite for wallet linking.

Depends on auth PR [zif-terminal/auth#11](https://github.com/zif-terminal/auth/pull/11) (POST /auth/register backend endpoint).

## Test plan
- [x] Build passes with no errors
- [ ] Navigate to /signup — registration form renders with email, username, password, confirm password fields
- [ ] Submit valid registration — creates account, sets auth cookie, redirects to /accounts
- [ ] Submit duplicate email — shows 409 error "Email already registered"
- [ ] Submit weak password (<8 chars) — client-side validation prevents submission
- [ ] Mismatched passwords — client-side validation prevents submission
- [ ] Click "Sign in" link from signup → navigates to /login
- [ ] Click "Sign up" link from login → navigates to /signup
- [ ] Visit /signup while logged in → redirects to /accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)