### PR TITLE
feat: add sorting and side filter to trade history page

### DIFF
--- a/src/app/(dashboard)/trades/page.tsx
+++ b/src/app/(dashboard)/trades/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { api, DataFilters } from "@/lib/api";
 import { Trade, ExchangeAccount, TradesAggregates } from "@/lib/queries";
 import { TradesTable } from "@/components/trades-table";
@@ -19,27 +19,41 @@ import {
 import { DateRangeFilter } from "@/components/date-range-filter";
 import { AssetFilter } from "@/components/asset-filter";
 import { MarketTypeFilter } from "@/components/market-type-filter";
+import { SideFilter } from "@/components/side-filter";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
+import { SortConfig } from "@/lib/api";
 
 const PAGE_SIZE = 100;
-
-async function fetchTrades(
-  limit: number,
-  offset: number,
-  filters: DataFilters
-) {
-  const data = await api.getTrades(limit, offset, filters);
-  return { items: data.trades, totalCount: data.totalCount };
-}
-
-async function fetchTradesAggregates(filters: DataFilters) {
-  return api.getTradesAggregates(filters);
-}
 
 export default function TradesPage() {
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
   const [availableAssets, setAvailableAssets] = useState<string[]>([]);
   const [isLoadingAssets, setIsLoadingAssets] = useState(true);
+  const [selectedSide, setSelectedSide] = useState<"buy" | "sell" | null>(null);
+
+  // Wrap fetch functions to inject side filter
+  const fetchTrades = useCallback(
+    async (limit: number, offset: number, filters: DataFilters) => {
+      const filtersWithSide: DataFilters = {
+        ...filters,
+        side: selectedSide ?? undefined,
+      };
+      const data = await api.getTrades(limit, offset, filtersWithSide);
+      return { items: data.trades, totalCount: data.totalCount };
+    },
+    [selectedSide]
+  );
+
+  const fetchTradesAggregates = useCallback(
+    async (filters: DataFilters) => {
+      const filtersWithSide: DataFilters = {
+        ...filters,
+        side: selectedSide ?? undefined,
+      };
+      return api.getTradesAggregates(filtersWithSide);
+    },
+    [selectedSide]
+  );
 
   const {
     items: trades,
@@ -52,12 +66,14 @@ export default function TradesPage() {
     dateRange,
     selectedAssets,
     selectedMarketTypes,
+    sort,
     isNew,
     handlePageChange,
     handleAccountChange,
     handleDateRangeChange,
     handleAssetChange,
     handleMarketTypeChange,
+    handleSortChange,
     refresh,
     lastRefreshTime,
   } = usePaginatedData<Trade, TradesAggregates>({
@@ -66,6 +82,15 @@ export default function TradesPage() {
     pageSize: PAGE_SIZE,
     useGlobalTags: true,
   });
+
+  // Refresh when side filter changes
+  useEffect(() => {
+    refresh();
+  }, [selectedSide]);
+
+  const handleSideChange = useCallback((side: "buy" | "sell" | null) => {
+    setSelectedSide(side);
+  }, []);
 
   useEffect(() => {
     const fetchAccounts = async () => {
@@ -165,6 +190,7 @@ export default function TradesPage() {
               value={selectedMarketTypes}
               onChange={handleMarketTypeChange}
             />
+            <SideFilter value={selectedSide} onChange={handleSideChange} />
             <DateRangeFilter value={dateRange} onChange={handleDateRangeChange} />
           </FilterBar>
         </CardHeader>
@@ -178,6 +204,8 @@ export default function TradesPage() {
             showAccount={true}
             isLoading={isLoading}
             isNewItem={isNew}
+            sort={sort}
+            onSortChange={handleSortChange}
           />
         </CardContent>
       </Card>

--- a/src/components/side-filter.tsx
+++ b/src/components/side-filter.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface SideFilterProps {
+  value: "buy" | "sell" | null;
+  onChange: (side: "buy" | "sell" | null) => void;
+}
+
+export function SideFilter({ value, onChange }: SideFilterProps) {
+  const options: { label: string; side: "buy" | "sell" | null }[] = [
+    { label: "All", side: null },
+    { label: "Buy", side: "buy" },
+    { label: "Sell", side: "sell" },
+  ];
+
+  return (
+    <div className="flex items-center gap-1">
+      {options.map((opt) => (
+        <Button
+          key={opt.label}
+          variant="outline"
+          size="sm"
+          className={cn(
+            "h-8 px-3 text-xs",
+            value === opt.side && "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+          )}
+          onClick={() => onChange(opt.side)}
+        >
+          {opt.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/trades-table.tsx
+++ b/src/components/trades-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Trade } from "@/lib/queries";
+import { SortConfig, SortDirection } from "@/lib/api";
 import {
   Table,
   TableBody,
@@ -15,6 +16,8 @@ import { ExchangeBadge } from "@/components/exchange-badge";
 import { getDisplayName } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
+type SortableColumn = "timestamp" | "price" | "quantity" | "fee";
+
 interface TradesTableProps {
   trades: Trade[];
   totalCount: number;
@@ -25,6 +28,10 @@ interface TradesTableProps {
   isLoading?: boolean;
   /** Function to check if a trade is new (for highlighting) */
   isNewItem?: (id: string) => boolean;
+  /** Current sort configuration */
+  sort?: SortConfig | null;
+  /** Called when a sortable column header is clicked */
+  onSortChange?: (sort: SortConfig | null) => void;
 }
 
 function formatTimestamp(timestamp: string): string {
@@ -41,6 +48,13 @@ function formatNumber(value: string, decimals: number = 4): string {
   });
 }
 
+function SortIndicator({ column, sort }: { column: SortableColumn; sort?: SortConfig | null }) {
+  if (!sort || sort.column !== column) {
+    return <span className="text-muted-foreground/30 ml-1">{"\u2191\u2193"}</span>;
+  }
+  return <span className="ml-1">{sort.direction === "asc" ? "\u2191" : "\u2193"}</span>;
+}
+
 export function TradesTable({
   trades,
   totalCount,
@@ -50,10 +64,32 @@ export function TradesTable({
   showAccount = false,
   isLoading = false,
   isNewItem,
+  sort,
+  onSortChange,
 }: TradesTableProps) {
   const totalPages = Math.ceil(totalCount / pageSize);
   const startItem = page * pageSize + 1;
   const endItem = Math.min((page + 1) * pageSize, totalCount);
+
+  const handleSort = (column: SortableColumn) => {
+    if (!onSortChange) return;
+    if (sort?.column === column) {
+      onSortChange({ column, direction: sort.direction === "asc" ? "desc" : "asc" });
+    } else {
+      const defaultDir: SortDirection = column === "timestamp" ? "desc" : "desc";
+      onSortChange({ column, direction: defaultDir });
+    }
+  };
+
+  const sortableHeader = (label: string, column: SortableColumn, className?: string) => (
+    <TableHead
+      className={cn("cursor-pointer select-none hover:text-foreground", className)}
+      onClick={() => handleSort(column)}
+    >
+      {label}
+      <SortIndicator column={column} sort={sort} />
+    </TableHead>
+  );
 
   // Only show skeleton on initial load (when there's no data yet)
   if (isLoading && trades.length === 0) {
@@ -76,12 +112,12 @@ export function TradesTable({
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Time</TableHead>
+            {sortableHeader("Time", "timestamp")}
             <TableHead>Pair</TableHead>
             <TableHead>Side</TableHead>
-            <TableHead className="text-right">Price</TableHead>
-            <TableHead className="text-right">Quantity</TableHead>
-            <TableHead className="text-right">Fee</TableHead>
+            {sortableHeader("Price", "price", "text-right")}
+            {sortableHeader("Quantity", "quantity", "text-right")}
+            {sortableHeader("Fee", "fee", "text-right")}
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -131,6 +131,10 @@ function buildTradesWhereClause(filters?: DataFilters): Record<string, unknown> 
     conditions.push({ market_type: { _in: filters.marketTypes } });
   }
 
+  if (filters?.side) {
+    conditions.push({ side: { _eq: filters.side } });
+  }
+
   if (filters?.tags && filters.tags.length > 0) {
     conditions.push(buildTagConditions(filters.tags));
   }
@@ -354,10 +358,14 @@ export const graphqlApi: ApiClient = {
       const client = getGraphQLClient();
       const where = buildTradesWhereClause(filters);
 
+      const orderBy = filters?.sort
+        ? [{ [filters.sort.column]: filters.sort.direction }]
+        : [{ timestamp: "desc" }];
+
       const data = await client.request<{
         trades: Trade[];
         trades_aggregate: { aggregate: { count: number } };
-      }>(GET_TRADES_DYNAMIC, { limit, offset, where });
+      }>(GET_TRADES_DYNAMIC, { limit, offset, where, order_by: orderBy });
 
       return {
         trades: data.trades,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -66,6 +66,7 @@ export interface DataFilters {
   until?: number;
   baseAssets?: string[];
   marketTypes?: ("perp" | "spot" | "swap")[];
+  side?: "buy" | "sell";
   tags?: string[];
   exchangeIds?: string[];
   timeField?: "start_time" | "end_time";

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -996,8 +996,8 @@ export const GET_DISTINCT_FUNDING_ASSETS = gql`
 
 // Dynamic filter queries - accept where clause as variable
 export const GET_TRADES_DYNAMIC = gql`
-  query GetTradesDynamic($limit: Int!, $offset: Int!, $where: trades_bool_exp!) {
-    trades(limit: $limit, offset: $offset, order_by: { timestamp: desc }, where: $where) {
+  query GetTradesDynamic($limit: Int!, $offset: Int!, $where: trades_bool_exp!, $order_by: [trades_order_by!]) {
+    trades(limit: $limit, offset: $offset, order_by: $order_by, where: $where) {
       id
       base_asset
       quote_asset


### PR DESCRIPTION
## Summary
- **Sortable columns**: Timestamp, Price, Quantity, and Fee column headers are now clickable to sort server-side (asc/desc toggle with visual indicators)
- **Side filter**: New Buy/Sell/All toggle buttons to filter trades by side
- **Dynamic GraphQL ordering**: `GET_TRADES_DYNAMIC` query now accepts `$order_by` variable instead of hardcoded `{ timestamp: desc }`, matching the positions query pattern

## Changes
- `src/lib/queries.ts` — Added `$order_by: [trades_order_by!]` variable to trades query
- `src/lib/api/graphql.ts` — `getTrades()` builds `order_by` from `filters.sort`, added `side` to where clause builder
- `src/lib/api/types.ts` — Added `side?: "buy" | "sell"` to `DataFilters`
- `src/components/trades-table.tsx` — Sortable column headers with `SortIndicator`, accepts `sort`/`onSortChange` props
- `src/components/side-filter.tsx` — New component: All/Buy/Sell toggle buttons
- `src/app/(dashboard)/trades/page.tsx` — Wired sort and side filter state, added SideFilter to FilterBar

## Test plan
- [ ] Verify trade history page loads with existing data
- [ ] Click column headers (Time, Price, Quantity, Fee) — verify sort order changes and indicator updates
- [ ] Toggle Buy/Sell/All filter — verify table filters correctly
- [ ] Verify pagination still works with sorting and filtering active
- [ ] Verify existing filters (date range, asset, market type, account) still work

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)