### PR TITLE
feat: add trade export as CSV/JSON for tax compliance

### DIFF
--- a/src/app/(dashboard)/trades/page.tsx
+++ b/src/app/(dashboard)/trades/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { api, DataFilters } from "@/lib/api";
 import { Trade, ExchangeAccount, TradesAggregates } from "@/lib/queries";
 import { TradesTable } from "@/components/trades-table";
@@ -20,7 +20,9 @@ import { DateRangeFilter } from "@/components/date-range-filter";
 import { AssetFilter } from "@/components/asset-filter";
 import { MarketTypeFilter } from "@/components/market-type-filter";
 import { SideFilter } from "@/components/side-filter";
+import { ExportButton } from "@/components/export-button";
 import { usePaginatedData } from "@/hooks/use-paginated-data";
+import { getTimestampsFromDateRange } from "@/components/date-range-filter";
 import { SortConfig } from "@/lib/api";
 
 const PAGE_SIZE = 100;
@@ -124,17 +126,32 @@ export default function TradesPage() {
     return num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 });
   };
 
+  // Build export params from current filter state
+  const exportParams = useMemo(() => {
+    const params: Record<string, string | undefined> = {};
+    const { since, until } = getTimestampsFromDateRange(dateRange);
+    if (since !== undefined) params.from = String(since);
+    if (until !== undefined) params.to = String(until);
+    if (selectedAssets.length === 1) params.asset = selectedAssets[0];
+    if (selectedSide) params.side = selectedSide;
+    if (selectedMarketTypes.length === 1) params.market_type = selectedMarketTypes[0];
+    return params;
+  }, [dateRange, selectedAssets, selectedSide, selectedMarketTypes]);
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Trade History"
         description="View all trades across your exchange accounts"
         action={
-          <SyncButton
-            lastRefreshTime={lastRefreshTime}
-            onRefresh={refresh}
-            isLoading={isLoading}
-          />
+          <div className="flex items-center gap-2">
+            <ExportButton endpoint="/api/export/trades" params={exportParams} />
+            <SyncButton
+              lastRefreshTime={lastRefreshTime}
+              onRefresh={refresh}
+              isLoading={isLoading}
+            />
+          </div>
         }
       />
 

--- a/src/app/api/export/trades/route.ts
+++ b/src/app/api/export/trades/route.ts
@@ -1,0 +1,279 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
+
+const HASURA_URL = process.env.HASURA_URL || "http://localhost:8080";
+const FETCH_PAGE_SIZE = 500;
+const MAX_EXPORT_ROWS = 50000;
+
+interface TradeRow {
+  id: string;
+  timestamp: string;
+  side: string;
+  base_asset: string;
+  quote_asset: string;
+  market_type: string;
+  quantity: string;
+  price: string;
+  fee: string;
+  order_id: string;
+  trade_id: string;
+  exchange_account: {
+    exchange: { name: string; display_name: string } | null;
+    account_identifier: string;
+    label: string | null;
+  } | null;
+}
+
+const TRADES_QUERY = `
+  query ExportTrades($limit: Int!, $offset: Int!, $where: trades_bool_exp!) {
+    trades(limit: $limit, offset: $offset, order_by: { timestamp: desc }, where: $where) {
+      id
+      timestamp
+      side
+      base_asset
+      quote_asset
+      market_type
+      quantity
+      price
+      fee
+      order_id
+      trade_id
+      exchange_account {
+        exchange { name display_name }
+        account_identifier
+        label
+      }
+    }
+    trades_aggregate(where: $where) {
+      aggregate { count }
+    }
+  }
+`;
+
+function buildWhereClause(params: URLSearchParams): Record<string, unknown> {
+  const conditions: Record<string, unknown>[] = [];
+
+  const from = params.get("from");
+  const to = params.get("to");
+  if (from) {
+    conditions.push({ timestamp: { _gte: from } });
+  }
+  if (to) {
+    conditions.push({ timestamp: { _lte: to } });
+  }
+
+  const exchange = params.get("exchange");
+  if (exchange) {
+    conditions.push({ exchange_account: { exchange: { name: { _eq: exchange } } } });
+  }
+
+  const asset = params.get("asset");
+  if (asset) {
+    conditions.push({ base_asset: { _eq: asset } });
+  }
+
+  const side = params.get("side");
+  if (side === "buy" || side === "sell") {
+    conditions.push({ side: { _eq: side } });
+  }
+
+  const marketType = params.get("market_type");
+  if (marketType) {
+    conditions.push({ market_type: { _eq: marketType } });
+  }
+
+  if (conditions.length === 0) return {};
+  if (conditions.length === 1) return conditions[0];
+  return { _and: conditions };
+}
+
+async function fetchAllTrades(
+  token: string,
+  where: Record<string, unknown>
+): Promise<{ trades: TradeRow[]; totalCount: number }> {
+  const allTrades: TradeRow[] = [];
+  let offset = 0;
+  let totalCount = 0;
+
+  while (offset < MAX_EXPORT_ROWS) {
+    const resp = await fetch(`${HASURA_URL}/v1/graphql`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        query: TRADES_QUERY,
+        variables: { limit: FETCH_PAGE_SIZE, offset, where },
+      }),
+    });
+
+    if (!resp.ok) {
+      throw new Error(`Hasura returned ${resp.status}`);
+    }
+
+    const data = await resp.json();
+    if (data.errors) {
+      throw new Error(data.errors[0]?.message || "GraphQL error");
+    }
+
+    const trades: TradeRow[] = data.data.trades;
+    totalCount = data.data.trades_aggregate.aggregate.count;
+    allTrades.push(...trades);
+
+    if (trades.length < FETCH_PAGE_SIZE) break;
+    offset += FETCH_PAGE_SIZE;
+  }
+
+  return { trades: allTrades, totalCount };
+}
+
+function formatTimestamp(ts: string): string {
+  const val = /^\d+$/.test(ts) ? Number(ts) : ts;
+  return new Date(val).toISOString();
+}
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function tradesToCsv(trades: TradeRow[]): string {
+  const headers = [
+    "date",
+    "type",
+    "exchange",
+    "base_asset",
+    "quote_asset",
+    "market_type",
+    "quantity",
+    "price",
+    "total_value",
+    "fee",
+    "order_id",
+    "trade_id",
+  ];
+
+  const rows = trades.map((t) => {
+    const qty = parseFloat(t.quantity) || 0;
+    const price = parseFloat(t.price) || 0;
+    const totalValue = (qty * price).toFixed(6);
+
+    return [
+      formatTimestamp(t.timestamp),
+      t.side,
+      t.exchange_account?.exchange?.name || "",
+      t.base_asset,
+      t.quote_asset,
+      t.market_type || "",
+      t.quantity,
+      t.price,
+      totalValue,
+      t.fee,
+      t.order_id || "",
+      t.trade_id || "",
+    ].map((v) => escapeCsvField(String(v)));
+  });
+
+  return [headers.join(","), ...rows.map((r) => r.join(","))].join("\n");
+}
+
+function tradesToJson(
+  trades: TradeRow[],
+  params: URLSearchParams
+): object {
+  const tradeObjects = trades.map((t) => {
+    const qty = parseFloat(t.quantity) || 0;
+    const price = parseFloat(t.price) || 0;
+
+    return {
+      date: formatTimestamp(t.timestamp),
+      type: t.side,
+      exchange: t.exchange_account?.exchange?.name || null,
+      base_asset: t.base_asset,
+      quote_asset: t.quote_asset,
+      market_type: t.market_type || null,
+      quantity: t.quantity,
+      price: t.price,
+      total_value: (qty * price).toFixed(6),
+      fee: t.fee,
+      order_id: t.order_id || null,
+      trade_id: t.trade_id || null,
+    };
+  });
+
+  return {
+    metadata: {
+      exported_at: new Date().toISOString(),
+      date_range: {
+        from: params.get("from") || null,
+        to: params.get("to") || null,
+      },
+      filters: {
+        exchange: params.get("exchange") || null,
+        asset: params.get("asset") || null,
+        side: params.get("side") || null,
+        market_type: params.get("market_type") || null,
+      },
+      total_trades: tradeObjects.length,
+    },
+    trades: tradeObjects,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return NextResponse.json(
+      { error: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const format = searchParams.get("format") || "csv";
+
+  if (format !== "csv" && format !== "json") {
+    return NextResponse.json(
+      { error: "Invalid format. Use 'csv' or 'json'" },
+      { status: 400 }
+    );
+  }
+
+  const where = buildWhereClause(searchParams);
+
+  let result: { trades: TradeRow[]; totalCount: number };
+  try {
+    result = await fetchAllTrades(token, where);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Export failed";
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+
+  const now = new Date().toISOString().slice(0, 10);
+
+  if (format === "json") {
+    const body = tradesToJson(result.trades, searchParams);
+    return new NextResponse(JSON.stringify(body, null, 2), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Disposition": `attachment; filename="zif-trades-${now}.json"`,
+      },
+    });
+  }
+
+  const csv = tradesToCsv(result.trades);
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="zif-trades-${now}.csv"`,
+    },
+  });
+}

--- a/src/components/export-button.tsx
+++ b/src/components/export-button.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface ExportButtonProps {
+  /** Base URL for the export endpoint */
+  endpoint: string;
+  /** Query parameters to include (filters) */
+  params?: Record<string, string | undefined>;
+}
+
+export function ExportButton({ endpoint, params }: ExportButtonProps) {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async (format: "csv" | "json") => {
+    setIsExporting(true);
+    try {
+      const url = new URL(endpoint, window.location.origin);
+      url.searchParams.set("format", format);
+      if (params) {
+        for (const [key, value] of Object.entries(params)) {
+          if (value !== undefined && value !== "") {
+            url.searchParams.set(key, value);
+          }
+        }
+      }
+
+      const response = await fetch(url.toString());
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error || `Export failed (${response.status})`);
+      }
+
+      // Extract filename from Content-Disposition header or generate one
+      const disposition = response.headers.get("Content-Disposition");
+      const filenameMatch = disposition?.match(/filename="?([^"]+)"?/);
+      const filename = filenameMatch?.[1] || `export.${format}`;
+
+      const blob = await response.blob();
+      const downloadUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = downloadUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(downloadUrl);
+    } catch (error) {
+      console.error("Export failed:", error);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" disabled={isExporting}>
+          {isExporting ? "Exporting..." : "Export"}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => handleExport("csv")}>
+          Export as CSV
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => handleExport("json")}>
+          Export as JSON
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- **New API route**: `GET /api/export/trades` — fetches all matching trades from Hasura (paginated, max 50k rows) and returns CSV or JSON with download headers
- **Export button**: Dropdown on trade history page header with "Export as CSV" and "Export as JSON" options
- **Filter passthrough**: Current page filters (date range, asset, side, market type) are forwarded as export query params

## Details

### CSV format
Columns: date, type, exchange, base_asset, quote_asset, market_type, quantity, price, total_value, fee, order_id, trade_id

### JSON format
Includes `metadata` wrapper with `exported_at`, `date_range`, `filters`, and `total_trades`, plus full `trades` array.

### Query params
- `format` — `csv` (default) or `json`
- `from` / `to` — timestamp range filter
- `exchange` — filter by exchange name
- `asset` — filter by base asset
- `side` — `buy` or `sell`
- `market_type` — perp, spot, or swap

### Security
- Authenticates via HttpOnly cookie token (same as GraphQL proxy)
- 401 returned if not authenticated
- Max 50k rows to prevent abuse

## Test plan
- [ ] Click Export > CSV — verify browser downloads a .csv file with correct headers and trade data
- [ ] Click Export > JSON — verify browser downloads a .json file with metadata wrapper
- [ ] Apply filters (date range, asset, side) then export — verify exported data matches filtered view
- [ ] Verify unauthenticated request to /api/export/trades returns 401
- [ ] Open CSV in spreadsheet software — verify columns parse correctly

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)