### PR TITLE
fix: use consistent TOKEN_COOKIE_NAME import in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-
-// Cookie name can be customized via env var to allow multiple instances on same host
-const COOKIE_SUFFIX = process.env.NEXT_PUBLIC_COOKIE_SUFFIX || "";
-const TOKEN_COOKIE_NAME = `zif_auth_token${COOKIE_SUFFIX}`;
+import { TOKEN_COOKIE_NAME } from "@/lib/cookie-config";
 
 // Paths that should redirect to the dashboard when the user is already logged in.
 // /login and /signup: no point showing auth forms to a logged-in user.


### PR DESCRIPTION
## Summary
Fixes login redirect issue by using consistent TOKEN_COOKIE_NAME configuration across the codebase.

## Problem
The middleware was redefining `TOKEN_COOKIE_NAME` with hardcoded logic instead of importing from `@/lib/cookie-config`. This caused a mismatch in the cookie name when environment variables were involved, preventing the middleware from recognizing authenticated users and redirecting them away from `/login`.

## Root Cause
- **Login API** (`/api/auth/login/route.ts`): Sets cookie using `TOKEN_COOKIE_NAME` imported from `@/lib/cookie-config`
- **Middleware** (`middleware.ts`): Was checking for a cookie using independently calculated `TOKEN_COOKIE_NAME` with hardcoded logic
- If the build-time or runtime values differed, the middleware wouldn't see the cookie

## Solution
Import `TOKEN_COOKIE_NAME` from `@/lib/cookie-config` in middleware, ensuring all files use the same cookie name configuration.

## Impact
Users will now be properly redirected to `/accounts` after successful login. The middleware will correctly identify authenticated users and handle auth redirects.

## Testing
- Middleware now uses consistent cookie name from central config
- Login tests should no longer timeout waiting for redirect
- All auth flows (login, logout, /me check) use the same cookie name source

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)