### PR TITLE
feat: add interest earned/paid per asset to portfolio

### DIFF
--- a/src/app/(dashboard)/portfolio/page.tsx
+++ b/src/app/(dashboard)/portfolio/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, Fragment } from "react";
 import { api, DataFilters, SortConfig } from "@/lib/api";
-import { Position, ExchangeAccount, PositionsAggregates } from "@/lib/queries";
+import { Position, ExchangeAccount, PositionsAggregates, InterestByAsset } from "@/lib/queries";
 import { PageHeader } from "@/components/page-header";
 import { SyncButton } from "@/components/sync-button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -71,6 +71,10 @@ export default function PortfolioPage() {
   const [isLoadingClosed, setIsLoadingClosed] = useState(true);
   const [closedAggregates, setClosedAggregates] = useState<PositionsAggregates | null>(null);
 
+  // Interest by asset state
+  const [interestByAsset, setInterestByAsset] = useState<InterestByAsset[]>([]);
+  const [isLoadingInterest, setIsLoadingInterest] = useState(true);
+
   const [expandedPositionId, setExpandedPositionId] = useState<string | null>(null);
   const [expandedTab, setExpandedTab] = useState<"trades" | "funding">("trades");
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null);
@@ -128,16 +132,31 @@ export default function PortfolioPage() {
     }
   }, [buildFilters, closedPage, sortColumn, sortDirection]);
 
+  // Load interest by asset
+  const fetchInterest = useCallback(async () => {
+    setIsLoadingInterest(true);
+    try {
+      const data = await api.getInterestByAsset(buildFilters());
+      setInterestByAsset(data);
+    } catch (error) {
+      console.error("Failed to fetch interest data:", error);
+    } finally {
+      setIsLoadingInterest(false);
+    }
+  }, [buildFilters]);
+
   useEffect(() => {
     fetchOpenPositions();
     fetchClosedPositions();
-  }, [fetchOpenPositions, fetchClosedPositions]);
+    fetchInterest();
+  }, [fetchOpenPositions, fetchClosedPositions, fetchInterest]);
 
   const refresh = useCallback(() => {
     fetchOpenPositions();
     fetchClosedPositions();
+    fetchInterest();
     setLastRefreshTime(new Date());
-  }, [fetchOpenPositions, fetchClosedPositions]);
+  }, [fetchOpenPositions, fetchClosedPositions, fetchInterest]);
 
   const handleAccountChange = (value: string) => {
     setSelectedAccountId(value);
@@ -280,6 +299,53 @@ export default function PortfolioPage() {
           isLoading={isLoadingClosed}
         />
       </StatsGrid>
+
+      {/* Interest Earned / Paid */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base md:text-lg">Interest Earned / Paid</CardTitle>
+        </CardHeader>
+        <CardContent className="px-2 md:px-6">
+          {isLoadingInterest && interestByAsset.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">Loading...</p>
+          ) : interestByAsset.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">No interest data</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Asset</TableHead>
+                  <TableHead className="text-right">Earned</TableHead>
+                  <TableHead className="text-right">Paid</TableHead>
+                  <TableHead className="text-right">Net</TableHead>
+                  <TableHead className="text-right">Payments</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {interestByAsset.map((row) => (
+                  <TableRow key={row.asset}>
+                    <TableCell className="py-3 font-medium">{row.asset}</TableCell>
+                    <TableCell className="py-3 text-right font-mono text-green-600">
+                      +{formatNumber(row.earned.toString())}
+                    </TableCell>
+                    <TableCell className="py-3 text-right font-mono text-red-600">
+                      -{formatNumber(row.paid.toString())}
+                    </TableCell>
+                    <TableCell className="py-3 text-right font-mono">
+                      <span className={row.net >= 0 ? "text-green-600" : "text-red-600"}>
+                        {row.net >= 0 ? "+" : ""}{formatNumber(row.net.toString())}
+                      </span>
+                    </TableCell>
+                    <TableCell className="py-3 text-right text-muted-foreground">
+                      {row.count}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Open Positions Section */}
       <Card>

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -44,6 +44,8 @@ import {
   Position,
   PositionsAggregates,
   GET_TRANSFERS_SUMMARY,
+  GET_INTEREST_BY_ASSET,
+  InterestByAsset,
 } from "../queries";
 import { ApiClient, CreateAccountInput, CreateWalletInput, TradesResult, FundingPaymentsResult, TransfersResult, InterestPaymentsResult, PositionsResult, DataFilters } from "./types";
 import { ApiError } from "./errors";
@@ -563,6 +565,41 @@ export const graphqlApi: ApiClient = {
         withdrawalCount: data.withdrawals.aggregate.count,
         interestCount: data.interest.aggregate.count,
       };
+    });
+  },
+
+  async getInterestByAsset(filters?: DataFilters): Promise<InterestByAsset[]> {
+    return withErrorHandling(async () => {
+      const client = getGraphQLClient();
+      const where = buildTransfersWhereClause(filters);
+
+      const data = await client.request<{
+        transfers: { asset: string; amount: string }[];
+      }>(GET_INTEREST_BY_ASSET, { where: Object.keys(where).length > 0 ? where : {} });
+
+      // Aggregate client-side by asset
+      const byAsset = new Map<string, { earned: number; paid: number; count: number }>();
+      for (const t of data.transfers) {
+        const amt = parseFloat(t.amount) || 0;
+        const entry = byAsset.get(t.asset) || { earned: 0, paid: 0, count: 0 };
+        if (amt >= 0) {
+          entry.earned += amt;
+        } else {
+          entry.paid += Math.abs(amt);
+        }
+        entry.count += 1;
+        byAsset.set(t.asset, entry);
+      }
+
+      return Array.from(byAsset.entries())
+        .map(([asset, { earned, paid, count }]) => ({
+          asset,
+          earned,
+          paid,
+          net: earned - paid,
+          count,
+        }))
+        .sort((a, b) => Math.abs(b.net) - Math.abs(a.net));
     });
   },
 

--- a/src/lib/api/mock.ts
+++ b/src/lib/api/mock.ts
@@ -1,4 +1,4 @@
-import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates, Wallet, WalletWithAccounts, Transfer, TransfersSummary, FundingAssetBreakdown, ExchangeFundingBreakdown } from "../queries";
+import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates, Wallet, WalletWithAccounts, Transfer, TransfersSummary, FundingAssetBreakdown, ExchangeFundingBreakdown, InterestByAsset } from "../queries";
 import { ApiClient, CreateAccountInput, CreateWalletInput, TradesResult, FundingPaymentsResult, TransfersResult, InterestPaymentsResult, DataFilters } from "./types";
 
 // Mock wallets
@@ -412,6 +412,11 @@ export const mockApi: ApiClient = {
   async getTransfersSummary(_filters?: DataFilters): Promise<TransfersSummary> {
     await delay(200);
     return { totalDepositsUSD: 0, totalWithdrawalsUSD: 0, totalInterestUSD: 0, netFlowUSD: 0, depositCount: 0, withdrawalCount: 0, interestCount: 0 };
+  },
+
+  async getInterestByAsset(_filters?: DataFilters): Promise<InterestByAsset[]> {
+    await delay(200);
+    return [];
   },
 
   async getDistinctTransferAssets(): Promise<string[]> {

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,4 +1,4 @@
-import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates, Wallet, WalletWithAccounts, Transfer, TransfersSummary, FundingAssetBreakdown, ExchangeFundingBreakdown, InterestPayment, Position, PositionsAggregates } from "../queries";
+import { Exchange, ExchangeAccount, ExchangeAccountType, Trade, TradesAggregates, FundingPayment, FundingAggregates, Wallet, WalletWithAccounts, Transfer, TransfersSummary, FundingAssetBreakdown, ExchangeFundingBreakdown, InterestPayment, InterestByAsset, Position, PositionsAggregates } from "../queries";
 
 export interface CreateAccountInput {
   exchange_id: string;
@@ -90,6 +90,7 @@ export interface ApiClient {
   // Transfer methods
   getTransfers(limit: number, offset: number, filters?: DataFilters): Promise<TransfersResult>;
   getTransfersSummary(filters?: DataFilters): Promise<TransfersSummary>;
+  getInterestByAsset(filters?: DataFilters): Promise<InterestByAsset[]>;
   getDistinctTransferAssets(): Promise<string[]>;
   // Interest payments (Transfers page)
   getInterestPayments(limit: number, offset: number, filters?: DataFilters): Promise<InterestPaymentsResult>;

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1344,6 +1344,24 @@ export interface TransfersSummary {
   interestCount: number;
 }
 
+// Interest per asset (for portfolio page)
+export const GET_INTEREST_BY_ASSET = gql`
+  query GetInterestByAsset($where: transfers_bool_exp!) {
+    transfers(where: { _and: [$where, { type: { _eq: "interest" } }] }, order_by: { timestamp: desc }) {
+      asset
+      amount
+    }
+  }
+`;
+
+export interface InterestByAsset {
+  asset: string;
+  earned: number;
+  paid: number;
+  net: number;
+  count: number;
+}
+
 // Per-exchange funding breakdown (used on funding page, A6.2)
 export interface ExchangeFundingBreakdown {
   exchangeId: string;


### PR DESCRIPTION
## Summary
- Adds a new "Interest Earned / Paid" section to the portfolio page
- Shows per-asset breakdown: earned, paid, net amount, and payment count
- Data comes from the transfers table (type='interest'), aggregated client-side
- Respects existing account/market filters

## Test plan
- [x] `next build` passes
- [ ] Verify interest data renders correctly on prod dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)