### PR TITLE
Get quote_asset from trade instead of position

### DIFF
--- a/src/app/(dashboard)/portfolio/page.tsx
+++ b/src/app/(dashboard)/portfolio/page.tsx
@@ -646,7 +646,7 @@ export default function PortfolioPage() {
                                                 <span>qty: {formatNumber(evt.quantity)}</span>
                                                 {price && (
                                                   <span className="text-muted-foreground">
-                                                    @ {formatPrice(price, pos.quote_asset)}
+                                                    @ {formatPrice(price, evt.trade?.quote_asset ?? "")}
                                                   </span>
                                                 )}
                                                 <span className="text-xs text-muted-foreground/50 ml-auto">
@@ -678,7 +678,7 @@ export default function PortfolioPage() {
                                                 <span>qty: {formatNumber(evt.quantity)}</span>
                                                 {price && (
                                                   <span className="text-muted-foreground">
-                                                    @ {formatPrice(price, pos.quote_asset)}
+                                                    @ {formatPrice(price, evt.trade?.quote_asset ?? "")}
                                                   </span>
                                                 )}
                                                 <span className="text-xs text-muted-foreground/50 ml-auto">

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1125,7 +1125,6 @@ export interface Position {
   side: "long" | "short";
   status: "open" | "closed";
   quantity: string;
-  quote_asset: string;
   start_time: number; // Unix milliseconds (BIGINT)
   end_time: number | null; // Unix milliseconds (BIGINT), null if open
   updated_at: string;
@@ -1143,6 +1142,7 @@ export interface PositionEvent {
   created_at: string;
   trade?: {
     price: string;
+    quote_asset: string;
     timestamp: number;
   } | null;
   transfer?: {
@@ -1171,7 +1171,6 @@ const POSITION_FIELDS = `
   side
   status
   quantity
-  quote_asset
   start_time
   end_time
   updated_at
@@ -1199,6 +1198,7 @@ const POSITION_FIELDS = `
     created_at
     trade {
       price
+      quote_asset
       timestamp
     }
     transfer {


### PR DESCRIPTION
## Summary
- Drop unused `event_values` table (dead code, never wired)
- Drop `quote_asset` column from `positions` table (no price columns remain)
- Remove `QuoteAsset` from `PositionState` in-memory struct
- Remove `quoteAsset` parameter from `applyPositionChange` (was only used to persist to DB)
- Dashboard now reads `quote_asset` from trade via position_events instead of position
- Bump processor schema version to 54 (full reprocess)

## Merge order
1. **lib** — model/db changes
2. **activity_processor** — processor logic (depends on lib)
3. **infrastructure** — migrations + Hasura metadata
4. **web-dashboard** — frontend (independent, can go with infra)

## Test plan
- [x] Processor rebuilds from scratch with schema v54
- [x] 8 open + 2672 closed positions written successfully
- [x] 13663 position events linked
- [x] Hasura queries work without quote_asset
- [x] Dashboard hot-reloads with updated queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)