### PR TITLE
fix: correct wallet unique constraint name

### DIFF
--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -111,7 +111,7 @@ export const CREATE_WALLET = gql`
   mutation CreateWallet($address: String!, $chain: String!) {
     insert_wallets_one(
       object: { address: $address, chain: $chain }
-      on_conflict: { constraint: wallets_user_address_chain_key, update_columns: [] }
+      on_conflict: { constraint: wallets_address_chain_key, update_columns: [] }
     ) {
       id
       address


### PR DESCRIPTION
## Summary
- Fixes `wallets_user_address_chain_key` → `wallets_address_chain_key` in CREATE_WALLET mutation
- The constraint was renamed in the DB migration but the GraphQL query still referenced the old name

## Test plan
- [x] Wallet creation tested locally — upsert succeeds without constraint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)