### PR TITLE
feat: show interest USDC values in portfolio page

### DIFF
--- a/src/app/(dashboard)/portfolio/page.tsx
+++ b/src/app/(dashboard)/portfolio/page.tsx
@@ -464,32 +464,37 @@ export default function PortfolioPage() {
                       <TableHead className="text-right">Earned</TableHead>
                       <TableHead className="text-right">Paid</TableHead>
                       <TableHead className="text-right">Net</TableHead>
-                      <TableHead className="text-right">Value (USDC)</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {interestByAsset.map((row) => (
                       <TableRow key={row.asset}>
                         <TableCell className="py-2 font-medium text-sm">{row.asset}</TableCell>
-                        <TableCell className="py-2 text-right font-mono text-sm text-green-600">
-                          +{formatNumber(row.earned.toString())}
-                        </TableCell>
-                        <TableCell className="py-2 text-right font-mono text-sm text-red-600">
-                          -{formatNumber(row.paid.toString())}
+                        <TableCell className="py-2 text-right font-mono text-sm">
+                          <div>
+                            <span className="text-green-600">+{formatNumber(row.earned.toString())}</span>
+                            {row.earnedValue > 0 && (
+                              <div className="text-muted-foreground text-xs">${formatUSD(row.earnedValue)}</div>
+                            )}
+                          </div>
                         </TableCell>
                         <TableCell className="py-2 text-right font-mono text-sm">
-                          <span className={row.net >= 0 ? "text-green-600" : "text-red-600"}>
-                            {row.net >= 0 ? "+" : ""}{formatNumber(row.net.toString())}
-                          </span>
+                          <div>
+                            <span className="text-red-600">-{formatNumber(row.paid.toString())}</span>
+                            {row.paidValue > 0 && (
+                              <div className="text-muted-foreground text-xs">${formatUSD(row.paidValue)}</div>
+                            )}
+                          </div>
                         </TableCell>
                         <TableCell className="py-2 text-right font-mono text-sm">
-                          {row.netValue !== 0 ? (
-                            <span className={row.netValue >= 0 ? "text-green-600" : "text-red-600"}>
-                              ${formatSignedNumber(row.netValue.toFixed(2))}
+                          <div>
+                            <span className={row.net >= 0 ? "text-green-600" : "text-red-600"}>
+                              {row.net >= 0 ? "+" : ""}{formatNumber(row.net.toString())}
                             </span>
-                          ) : (
-                            <span className="text-muted-foreground">-</span>
-                          )}
+                            {row.netValue !== 0 && (
+                              <div className="text-muted-foreground text-xs">${formatUSD(Math.abs(row.netValue))}</div>
+                            )}
+                          </div>
                         </TableCell>
                       </TableRow>
                     ))}

--- a/src/app/(dashboard)/portfolio/page.tsx
+++ b/src/app/(dashboard)/portfolio/page.tsx
@@ -290,8 +290,8 @@ export default function PortfolioPage() {
         </Select>
       </div>
 
-      {/* PnL Summary — server-side aggregated, respects all filters */}
-      <StatsGrid columns={4}>
+      {/* Summary — server-side aggregated, respects all filters */}
+      <StatsGrid columns={5}>
         <StatCard
           title="Realized PnL"
           value={pnlAggregates ? `$${formatSignedNumber(pnlAggregates.total.pnl.toFixed(2))}` : "-"}
@@ -310,6 +310,17 @@ export default function PortfolioPage() {
           isLoading={isLoadingPnl}
           valueClassName={pnlAggregates && pnlAggregates.spot.pnl >= 0 ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}
         />
+        {(() => {
+          const totalInterestValue = interestByAsset.reduce((sum, row) => sum + row.netValue, 0);
+          return (
+            <StatCard
+              title="Interest (USDC)"
+              value={`$${formatSignedNumber(totalInterestValue.toFixed(2))}`}
+              isLoading={isLoadingInterest}
+              valueClassName={totalInterestValue >= 0 ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}
+            />
+          );
+        })()}
         <StatCard
           title="Closed Positions"
           value={closedAggregates?.count ?? 0}
@@ -453,6 +464,7 @@ export default function PortfolioPage() {
                       <TableHead className="text-right">Earned</TableHead>
                       <TableHead className="text-right">Paid</TableHead>
                       <TableHead className="text-right">Net</TableHead>
+                      <TableHead className="text-right">Value (USDC)</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -469,6 +481,15 @@ export default function PortfolioPage() {
                           <span className={row.net >= 0 ? "text-green-600" : "text-red-600"}>
                             {row.net >= 0 ? "+" : ""}{formatNumber(row.net.toString())}
                           </span>
+                        </TableCell>
+                        <TableCell className="py-2 text-right font-mono text-sm">
+                          {row.netValue !== 0 ? (
+                            <span className={row.netValue >= 0 ? "text-green-600" : "text-red-600"}>
+                              ${formatSignedNumber(row.netValue.toFixed(2))}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">-</span>
+                          )}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -557,32 +557,38 @@ export const graphqlApi: ApiClient = {
       const where = buildTransfersWhereClause(filters);
 
       const data = await client.request<{
-        transfers: { asset: string; amount: string }[];
+        transfers: { id: string; asset: string; amount: string; event_values: { quantity: string }[] }[];
       }>(GET_INTEREST_BY_ASSET, { where: Object.keys(where).length > 0 ? where : {} });
 
       // Aggregate client-side by asset
-      const byAsset = new Map<string, { earned: number; paid: number; count: number }>();
+      const byAsset = new Map<string, { earned: number; paid: number; count: number; earnedValue: number; paidValue: number }>();
       for (const t of data.transfers) {
         const amt = parseFloat(t.amount) || 0;
-        const entry = byAsset.get(t.asset) || { earned: 0, paid: 0, count: 0 };
+        const usdcValue = t.event_values.length > 0 ? Math.abs(parseFloat(t.event_values[0].quantity) || 0) : 0;
+        const entry = byAsset.get(t.asset) || { earned: 0, paid: 0, count: 0, earnedValue: 0, paidValue: 0 };
         if (amt >= 0) {
           entry.earned += amt;
+          entry.earnedValue += usdcValue;
         } else {
           entry.paid += Math.abs(amt);
+          entry.paidValue += usdcValue;
         }
         entry.count += 1;
         byAsset.set(t.asset, entry);
       }
 
       return Array.from(byAsset.entries())
-        .map(([asset, { earned, paid, count }]) => ({
+        .map(([asset, { earned, paid, count, earnedValue, paidValue }]) => ({
           asset,
           earned,
           paid,
           net: earned - paid,
           count,
+          earnedValue,
+          paidValue,
+          netValue: earnedValue - paidValue,
         }))
-        .sort((a, b) => Math.abs(b.net) - Math.abs(a.net));
+        .sort((a, b) => Math.abs(b.netValue) - Math.abs(a.netValue));
     });
   },
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1417,8 +1417,12 @@ export interface TransfersSummary {
 export const GET_INTEREST_BY_ASSET = gql`
   query GetInterestByAsset($where: transfers_bool_exp!) {
     transfers(where: { _and: [$where, { type: { _eq: "interest" } }] }, order_by: { timestamp: desc }) {
+      id
       asset
       amount
+      event_values(where: { denomination: { _eq: "USDC" } }) {
+        quantity
+      }
     }
   }
 `;
@@ -1429,6 +1433,9 @@ export interface InterestByAsset {
   paid: number;
   net: number;
   count: number;
+  earnedValue: number;
+  paidValue: number;
+  netValue: number;
 }
 
 // Per-exchange funding breakdown (used on funding page, A6.2)


### PR DESCRIPTION
## Summary
- Add Value (USDC) column to interest table showing the USDC value of each asset's interest
- Add Interest (USDC) stat card showing total net interest value
- Query event_values alongside interest transfers for USDC denomination
- Sort interest table by net USDC value (most impactful first)

## Test plan
- [ ] Interest table shows Value column with USDC amounts
- [ ] USDC interest shows value (identity), non-USDC shows value where event_values exist
- [ ] Interest stat card shows total across all assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)