### PR TITLE
fix: consistent account names and persist filters across refresh

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { useGlobalTags } from "@/contexts/filters-context";
 import { useDenomination } from "@/contexts/denomination-context";
 import { useAccountFilter } from "@/contexts/account-filter-context";
+import { ExchangeAccount } from "@/lib/queries";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { TagFilter } from "@/components/tag-filter";
@@ -33,6 +34,13 @@ const navigation = [
   { name: "Accounts", href: "/accounts" },
 ];
 
+function accountDisplayName(acct: ExchangeAccount): string {
+  const exchange = acct.exchange?.display_name || "Unknown";
+  if (acct.label) return `${acct.label} (${exchange})`;
+  if (acct.wallet?.label) return `${acct.wallet.label} - ${acct.account_identifier.slice(0, 6)}... (${exchange})`;
+  return `${acct.account_identifier.slice(0, 8)}... (${exchange})`;
+}
+
 function AccountSelector() {
   const { accounts, selectedAccountIds, setSelectedAccountIds } = useAccountFilter();
 
@@ -43,9 +51,7 @@ function AccountSelector() {
         ? (() => {
             const acct = accounts.find((a) => a.id === selectedAccountIds[0]);
             if (!acct) return "1 account";
-            return acct.label || acct.wallet?.label
-              ? `${acct.wallet?.label || ""} ${acct.exchange?.display_name || ""}`.trim()
-              : `${acct.exchange?.display_name || ""} ${acct.account_identifier.slice(0, 8)}...`;
+            return accountDisplayName(acct);
           })()
         : `${selectedAccountIds.length} accounts`;
 
@@ -64,7 +70,7 @@ function AccountSelector() {
           {label}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-[240px]">
+      <DropdownMenuContent align="end" className="w-[260px]">
         <DropdownMenuCheckboxItem
           checked={selectedAccountIds.length === 0}
           onCheckedChange={() => setSelectedAccountIds([])}
@@ -78,10 +84,7 @@ function AccountSelector() {
             onCheckedChange={() => toggleAccount(acct.id)}
           >
             <span className="truncate">
-              {acct.label ||
-                (acct.wallet?.label
-                  ? `${acct.wallet.label} - ${acct.exchange?.display_name || ""}`
-                  : `${acct.exchange?.display_name || ""} - ${acct.account_identifier.slice(0, 10)}...`)}
+              {accountDisplayName(acct)}
             </span>
           </DropdownMenuCheckboxItem>
         ))}

--- a/src/contexts/account-filter-context.tsx
+++ b/src/contexts/account-filter-context.tsx
@@ -17,7 +17,13 @@ const AccountFilterContext = createContext<AccountFilterState | undefined>(undef
 
 export function AccountFilterProvider({ children }: { children: ReactNode }) {
   const [accounts, setAccounts] = useState<ExchangeAccount[]>([]);
-  const [selectedAccountIds, setSelectedAccountIdsState] = useState<string[]>([]);
+  const [selectedAccountIds, setSelectedAccountIdsState] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const stored = localStorage.getItem("zif_selected_accounts");
+      return stored ? JSON.parse(stored) : [];
+    } catch { return []; }
+  });
   const [isLoadingAccounts, setIsLoadingAccounts] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
   const pathname = usePathname();
@@ -44,6 +50,7 @@ export function AccountFilterProvider({ children }: { children: ReactNode }) {
 
   const setSelectedAccountIds = useCallback((ids: string[]) => {
     setSelectedAccountIdsState(ids);
+    try { localStorage.setItem("zif_selected_accounts", JSON.stringify(ids)); } catch {}
   }, []);
 
   const refreshAccounts = useCallback(() => {

--- a/src/contexts/filters-context.tsx
+++ b/src/contexts/filters-context.tsx
@@ -16,7 +16,13 @@ interface FiltersState {
 const FiltersContext = createContext<FiltersState | undefined>(undefined);
 
 export function FiltersProvider({ children }: { children: ReactNode }) {
-  const [globalTags, setGlobalTagsState] = useState<string[]>([]);
+  const [globalTags, setGlobalTagsState] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const stored = localStorage.getItem("zif_selected_tags");
+      return stored ? JSON.parse(stored) : [];
+    } catch { return []; }
+  });
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [isLoadingTags, setIsLoadingTags] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
@@ -53,6 +59,7 @@ export function FiltersProvider({ children }: { children: ReactNode }) {
 
   const setGlobalTags = useCallback((tags: string[]) => {
     setGlobalTagsState(tags);
+    try { localStorage.setItem("zif_selected_tags", JSON.stringify(tags)); } catch {}
   }, []);
 
   const refreshTags = useCallback(() => {


### PR DESCRIPTION
## Summary
- Account selector shows same format (label + exchange) in both button and dropdown
- Account selection persists to localStorage across page refresh
- Tag selection persists to localStorage across page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)