### PR TITLE
Untangle: layer #256/#263/#264 onto consolidated main (bring FE up to running bundle index-CbtTyiBL)

### DIFF
--- a/src/components/ExitPlanner.tsx
+++ b/src/components/ExitPlanner.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useStore } from '../store/store';
 import { useMutations } from '../store/useMutations';
 import { priceBounds } from '../lib/series';
-import { pnlAt, ladderSummary } from '../lib/pnl';
+import { pnlAt, ladderSummary, hasDisplayableLiq } from '../lib/pnl';
 import { px, kc, k, col, pricePrecision } from '../lib/format';
 import { t } from '../ui/theme';
 import { useIsMobile } from '../lib/useIsMobile';
@@ -332,7 +332,10 @@ function drawOverlay(
     ctx.textAlign = 'left'; ctx.font = `600 9px ${t.mono}`; ctx.fillStyle = color; ctx.fillText(label, lx, yy);
   };
   tagLine(p.entry, '#8b95a0', 'ENTRY ' + fmtPrice(p.entry), [4, 3]);
-  if (p.liq > 0) tagLine(p.liq, t.amber, 'LIQ ' + fmtPrice(p.liq), [5, 3]);
+  // Display-only far-liq guard: skip an unreachably-far cross-margin liq so we
+  // don't draw a LIQ line hundreds of × off the chart (matches the "—" shown in
+  // the Positions liq field). Raw p.liq is untouched.
+  if (hasDisplayableLiq(p)) tagLine(p.liq, t.amber, 'LIQ ' + fmtPrice(p.liq), [5, 3]);
 
   // ── draggable exit levels ──
   const drawLevel = (l: OrderLevel, i: number, color: string) => {

--- a/src/components/Performance.tsx
+++ b/src/components/Performance.tsx
@@ -7,12 +7,13 @@ import { k, col, usd } from '../lib/format';
 import { useIsMobile } from '../lib/useIsMobile';
 import { windowBounds } from '../data/perfWindow';
 import {
-  PNL_COMPONENTS, bucketRows, groupRows, sumTotals,
-  type GroupRow,
+  PNL_COMPONENTS, bucketRows, groupRows, sumTotals, eventNet, eventContribution,
+  type GroupRow, type ComponentTotals,
 } from '../lib/pnlDaily';
 import { PnlChart } from './PnlChart';
-import { ClosedPositionsSection } from './ClosedPositions';
-import type { PnlDailyRow, PnlGranularity, PnlGroupBy } from '../types';
+import type {
+  PnlDailyRow, PnlGranularity, PnlGroupBy, PnlComponent, EventStreamRow, EventFilter,
+} from '../types';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Analytics (#250 rebuild; chart scroll/zoom + layout pass #252). Per
@@ -77,11 +78,16 @@ const GRANS: { k: PnlGranularity; label: string }[] = [
 ];
 
 const GROUP_BYS: { k: PnlGroupBy; label: string }[] = [
-  { k: 'none', label: 'None' },
+  { k: 'none', label: 'Type' },
   { k: 'asset', label: 'Asset' },
   { k: 'exch', label: 'Exchange' },
   { k: 'account', label: 'Account' },
 ];
+
+// How many drill-down events to pull per expanded row. Drill scopes are narrow (one
+// type / asset / exch / account within the range), but funding is dense, so cap the
+// pull; if a scope hits the cap the drill footer flags the Σ as partial.
+const EVENT_LIMIT = 1000;
 
 // Resolve a range mode → concrete [sinceMs, untilMs] from the real-now clock.
 function rangeBounds(mode: RangeMode, custom: { from: string; to: string }, now = Date.now()): { sinceMs: number; untilMs: number } {
@@ -271,13 +277,15 @@ export function Performance() {
         {JSON.stringify(bucketsAsc.map((b) => [b.bucketStart, round2(b.totals.totalPnl), round2(b.totals.hackPnl)]))}
       </div>
 
-      {/* (4) Breakdown — group-by re-slices the SAME mat_pnl_daily rows fetched
-          once for Analytics, no refetch. See the #252 note at the top of this
-          file for why this compact ranked table is not a duplicate of Closed
-          positions below: this sources ALL realized PnL (incl. the Drift hack
-          and funding/interest on still-open positions); Closed positions
-          sources only fully-closed trades. */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', margin: '30px 0 14px' }}>
+      {/* (4) Breakdown — the UNIFIED section (#256). One list of everything the book
+          made or lost in range: by TYPE (trade / funding / rewards / interest / fees /
+          hacks — which folds in partial + full closes) or grouped by asset / exchange /
+          account. Clicking ANY row drills into the agg_event_stream EVENTS that sum to
+          it. This replaces the old separate Breakdown + Closed-positions sections:
+          closed trades are just the trade-type events on closed positions, reachable by
+          drilling. Every number here comes from the SAME agg_pnl_daily rows fetched once
+          (no refetch on group-by); only the on-demand drill hits the network. */}
+      <div data-qa="breakdown-section" style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', margin: '30px 0 14px' }}>
         <h2 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>Breakdown</h2>
         <span style={{ flex: 1, minWidth: 8 }} />
         <div data-qa="group-row" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -286,29 +294,15 @@ export function Performance() {
         </div>
       </div>
 
-      {/* C2: clarify the residual between this table and Closed positions below. */}
       <p style={{ fontSize: 12.5, color: t.mut2, margin: '0 0 14px' }}>
-        Realized PnL in range (includes funding + partial-close PnL on still-open positions). Closed positions below shows only fully-closed trades' lifetime totals.
+        Everything realized in range — trades (partial + full closes), funding, rewards, interest, fees and hacks. Click any row to see the underlying events that sum to it.
       </p>
 
       {anaGroupBy === 'none' ? (
-        <p style={{ fontSize: 12.5, color: t.mut2 }}>Pick Asset, Exchange or Account above to break the totals down further.</p>
+        <TypeBreakdownTable totals={grand} loading={loading} sinceDay={sinceDay} untilDay={untilDay} />
       ) : (
-        <GroupBreakdownTable groups={groups} dim={anaGroupBy} loading={loading} />
+        <GroupBreakdownTable groups={groups} dim={anaGroupBy} loading={loading} sinceDay={sinceDay} untilDay={untilDay} />
       )}
-
-      {/* (5) Closed positions — reuses the existing closed-trades machinery +
-          Overview's Positions grouping/sorting pattern (see ClosedPositions.tsx). */}
-      {/* C1: use the SAME UTC-day-floored window as the Breakdown above. The
-          breakdown filters mat_pnl_daily by whole UTC day (day >= sinceDay),
-          while this list filters closed trades by exact ms; passing the raw
-          bounds.sinceMs/untilMs made the two disagree at the boundary. Floor to
-          the day so both describe the identical [sinceDay 00:00 .. untilDay
-          23:59:59] UTC window. */}
-      <ClosedPositionsSection
-        sinceMs={Date.parse(sinceDay + 'T00:00:00Z')}
-        untilMs={Date.parse(untilDay + 'T23:59:59Z')}
-      />
     </div>
   );
 }
@@ -324,14 +318,61 @@ function rangeLabel(mode: RangeMode): string {
   }
 }
 
-// ── (4) Breakdown table — one row per group, columns = the 6 components +
-// total, sorted by |total| descending (groupRows' own order — biggest movers
-// first, matching Positions' group ordering elsewhere in the app). Flat, no
-// nesting, no per-row chart/expansion — see the #252 note above for why. ─────
+// ── (4a) By-TYPE breakdown — one row per PnL component (trade / funding / rewards /
+// interest / fees / hacks). Each row's value is that component's contribution to the
+// header total; the 6 rows visibly sum to TOTAL PNL. Clicking a row drills into the
+// events that contribute to that bucket (agg_event_stream, <col> _neq 0). ──────────
+const TypeBreakdownTable: React.FC<{ totals: ComponentTotals; loading: boolean; sinceDay: string; untilDay: string }> = ({ totals, loading, sinceDay, untilDay }) => {
+  const perfExpanded = useStore((s) => s.perfExpanded);
+  const togglePerf = useStore((s) => s.togglePerf);
+  const rows = PNL_COMPONENTS.map((c) => ({ comp: c.k, label: c.label, v: totals[c.k] })).filter((r) => r.v !== 0);
+  return (
+    <Card style={{ padding: '4px 6px', overflow: 'hidden' }}>
+      {loading ? (
+        <div style={{ padding: '20px 14px', textAlign: 'center', fontSize: 12.5, color: t.mut }}>Loading…</div>
+      ) : rows.length === 0 ? (
+        <EmptyBreakdown />
+      ) : (
+        rows.map((r) => {
+          const key = `bd:type:${r.comp}`;
+          const expanded = !!perfExpanded[key];
+          return (
+            <div key={r.comp}>
+              <div
+                role="button"
+                data-qa="breakdown-row" data-row-key={`type:${r.comp}`}
+                onClick={() => togglePerf(key)}
+                style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '13px 14px', borderBottom: '1px solid #161c21', cursor: 'pointer' }}
+              >
+                <Mono style={{ fontSize: 11, color: t.mut2, width: 9 }}>{expanded ? '▾' : '▸'}</Mono>
+                <span style={{ fontSize: 13.5, fontWeight: 600 }}>{r.label}</span>
+                <span style={{ flex: 1 }} />
+                <Num v={r.v} bold qa="row-total" />
+              </div>
+              {expanded && (
+                <EventDrill
+                  sinceDay={sinceDay} untilDay={untilDay}
+                  filter={{ bucket: r.comp }} mode={r.comp} expected={r.v}
+                />
+              )}
+            </div>
+          );
+        })
+      )}
+    </Card>
+  );
+};
+
+// ── (4b) Grouped breakdown — one row per asset / exchange / account, columns = the 6
+// components + total, sorted by |total| descending. Clicking a row drills into ALL of
+// that group's events (agg_event_stream scoped to the group), whose NET sums to the
+// row Total. Replaces the old flat table + the separate Closed-positions section. ────
 const VGRID = '1.3fr repeat(7,1fr) 1.1fr';
 
-const GroupBreakdownTable: React.FC<{ groups: GroupRow[]; dim: PnlGroupBy; loading: boolean }> = ({ groups, dim, loading }) => {
+const GroupBreakdownTable: React.FC<{ groups: GroupRow[]; dim: PnlGroupBy; loading: boolean; sinceDay: string; untilDay: string }> = ({ groups, dim, loading, sinceDay, untilDay }) => {
   const nameCol = dim === 'account' ? 'Account' : dim === 'exch' ? 'Exchange' : 'Asset';
+  const perfExpanded = useStore((s) => s.perfExpanded);
+  const togglePerf = useStore((s) => s.togglePerf);
   return (
     <Card style={{ padding: '4px 6px', overflowX: 'auto' }}>
       <div style={{ minWidth: 900 }}>
@@ -343,22 +384,38 @@ const GroupBreakdownTable: React.FC<{ groups: GroupRow[]; dim: PnlGroupBy; loadi
         {loading ? (
           <div style={{ padding: '20px 14px', textAlign: 'center', fontSize: 12.5, color: t.mut }}>Loading…</div>
         ) : groups.length === 0 ? (
-          <div style={{ padding: '30px 14px', textAlign: 'center' }}>
-            <div style={{ fontSize: 13.5, fontWeight: 600, color: t.mut }}>No PnL activity in this range</div>
-            <div style={{ fontSize: 12, color: t.mut2, marginTop: 5 }}>Try a wider range above.</div>
-          </div>
+          <EmptyBreakdown />
         ) : (
           groups.map((g) => {
             const dot = dim === 'exch' ? exchMeta[g.key]?.dot : dim === 'account' ? exchMeta[g.exch ?? '']?.dot : undefined;
+            const key = `bd:${dim}:${g.key}`;
+            const expanded = !!perfExpanded[key];
+            // Scope the drill to this group: asset/exch by their key, account by the
+            // exchange_account_id (groupKeyOf uses the id for the 'account' dim).
+            const filter: EventFilter = dim === 'asset' ? { asset: g.key } : dim === 'exch' ? { exch: g.key } : { accountId: g.key };
             return (
-              <div key={g.key} data-qa="group-row-item" data-group-key={g.key} style={{ display: 'grid', gridTemplateColumns: VGRID, gap: 8, padding: 13, borderBottom: '1px solid #161c21', alignItems: 'center' }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-                  {dot && <span style={{ width: 8, height: 8, borderRadius: 3, background: dot, flexShrink: 0 }} />}
-                  <Mono style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{g.label}</Mono>
-                  {dim === 'account' && g.exch && <span style={{ fontSize: 10.5, color: t.mut2, flexShrink: 0 }}>{g.exch}</span>}
+              <div key={g.key}>
+                <div
+                  role="button"
+                  data-qa="breakdown-row" data-row-key={`${dim}:${g.key}`}
+                  onClick={() => togglePerf(key)}
+                  style={{ display: 'grid', gridTemplateColumns: VGRID, gap: 8, padding: 13, borderBottom: '1px solid #161c21', alignItems: 'center', cursor: 'pointer' }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                    <Mono style={{ fontSize: 11, color: t.mut2, width: 9, flexShrink: 0 }}>{expanded ? '▾' : '▸'}</Mono>
+                    {dot && <span style={{ width: 8, height: 8, borderRadius: 3, background: dot, flexShrink: 0 }} />}
+                    <Mono style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{g.label}</Mono>
+                    {dim === 'account' && g.exch && <span style={{ fontSize: 10.5, color: t.mut2, flexShrink: 0 }}>{g.exch}</span>}
+                  </div>
+                  {PNL_COMPONENTS.map((c) => <Num key={c.k} v={g.totals[c.k]} />)}
+                  <Num v={g.totals.totalPnl} bold qa="group-total" />
                 </div>
-                {PNL_COMPONENTS.map((c) => <Num key={c.k} v={g.totals[c.k]} />)}
-                <Num v={g.totals.totalPnl} bold qa="group-total" />
+                {expanded && (
+                  <EventDrill
+                    sinceDay={sinceDay} untilDay={untilDay}
+                    filter={filter} mode="net" expected={g.totals.totalPnl}
+                  />
+                )}
               </div>
             );
           })
@@ -367,6 +424,77 @@ const GroupBreakdownTable: React.FC<{ groups: GroupRow[]; dim: PnlGroupBy; loadi
     </Card>
   );
 };
+
+const EmptyBreakdown: React.FC = () => (
+  <div style={{ padding: '30px 14px', textAlign: 'center' }}>
+    <div style={{ fontSize: 13.5, fontWeight: 600, color: t.mut }}>No PnL activity in this range</div>
+    <div style={{ fontSize: 12, color: t.mut2, marginTop: 5 }}>Try a wider range above.</div>
+  </div>
+);
+
+// ── Drill-down: the agg_event_stream events that sum to the clicked row. `mode` is
+// 'net' (a group row → each event's signed net contribution) or a PnlComponent (a
+// type row → each event's contribution to that one bucket). The footer shows Σ of the
+// shown events, which equals `expected` (the row total) unless the EVENT_LIMIT cap was
+// hit — flagged as partial. data-qa hooks let the deploy gate assert Σ == expected. ──
+const EventDrill: React.FC<{ sinceDay: string; untilDay: string; filter: EventFilter; mode: 'net' | PnlComponent; expected: number }> = ({ sinceDay, untilDay, filter, mode, expected }) => {
+  const [events, setEvents] = useState<EventStreamRow[] | null>(null);
+  const [errored, setErrored] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    setEvents(null); setErrored(false);
+    dataSource.fetchEventStream(sinceDay, untilDay, filter, EVENT_LIMIT)
+      .then((r) => { if (alive) setEvents(r); })
+      .catch((e) => { console.error('[analytics] fetchEventStream failed', e); if (alive) setErrored(true); });
+    return () => { alive = false; };
+  }, [sinceDay, untilDay, JSON.stringify(filter), mode]);
+
+  const valueOf = (e: EventStreamRow): number => (mode === 'net' ? eventNet(e) : eventContribution(e, mode));
+  const shownSum = useMemo(() => (events ?? []).reduce((s, e) => s + valueOf(e), 0), [events, mode]);
+  const capped = !!events && events.length >= EVENT_LIMIT;
+
+  return (
+    <div style={{ background: '#12161a', borderBottom: '1px solid #161c21', padding: '6px 10px 12px' }}>
+      {errored ? (
+        <div style={{ padding: '12px 8px', fontSize: 12, color: '#f5c5c5' }}>Couldn't load events for this row.</div>
+      ) : events === null ? (
+        <div style={{ padding: '12px 8px', fontSize: 12, color: t.mut2 }}>Loading events…</div>
+      ) : events.length === 0 ? (
+        <div style={{ padding: '12px 8px', fontSize: 12, color: t.mut2 }}>No events in this range.</div>
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <div style={{ minWidth: 620 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: DGRID, gap: 8, padding: '8px 10px 6px' }}>
+              {['Date', 'Type', 'Asset', 'Account', 'Direction', mode === 'net' ? 'Net' : 'Value'].map((c, i) => (
+                <span key={i} style={{ fontSize: 9.5, letterSpacing: '.04em', color: '#6b7682', textTransform: 'uppercase', textAlign: i >= 4 ? 'right' : 'left' }}>{c}</span>
+              ))}
+            </div>
+            {events.map((e) => (
+              <div key={e.id} style={{ display: 'grid', gridTemplateColumns: DGRID, gap: 8, padding: '7px 10px', borderTop: '1px solid #1a2027', alignItems: 'center' }}>
+                <Mono style={{ fontSize: 11, color: t.mut2 }}>{e.day}</Mono>
+                <span style={{ fontSize: 11.5, fontWeight: 600 }}>{e.eventType || '—'}</span>
+                <Mono style={{ fontSize: 11.5 }}>{e.asset || '—'}</Mono>
+                <span style={{ fontSize: 11, color: t.mut2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.accountLabel || e.exch}</span>
+                <span style={{ fontSize: 10.5, color: t.mut2, textAlign: 'right' }}>{e.direction || '—'}</span>
+                <Num v={valueOf(e)} />
+              </div>
+            ))}
+            <div data-qa="drill-sum" data-expected={round2(expected)} data-actual={round2(shownSum)} data-count={events.length} data-capped={capped ? '1' : '0'}
+              style={{ display: 'grid', gridTemplateColumns: DGRID, gap: 8, padding: '9px 10px', borderTop: `1px solid ${t.border}`, alignItems: 'center' }}>
+              <span style={{ fontSize: 11, fontWeight: 600, color: t.mut, gridColumn: '1 / 5' }}>
+                {events.length} event{events.length === 1 ? '' : 's'}{capped ? ` (first ${EVENT_LIMIT} — Σ is partial)` : ''}
+              </span>
+              <span style={{ fontSize: 10.5, color: t.mut2, textAlign: 'right' }}>Σ</span>
+              <Num v={shownSum} bold />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const DGRID = '0.9fr 0.9fr 0.7fr 1.1fr 0.7fr 0.9fr';
 
 const Num: React.FC<{ v: number; bold?: boolean; qa?: string }> = ({ v, bold, qa }) => (
   <Mono data-qa={qa} title={usd(v)} style={{ fontSize: bold ? 14 : 13, fontWeight: bold ? 600 : 400, textAlign: 'right', color: col(v) }}>{k(v)}</Mono>

--- a/src/components/Positions.tsx
+++ b/src/components/Positions.tsx
@@ -4,7 +4,7 @@ import { Card, Mono, Segment } from '../ui/primitives';
 import { t, exchMeta } from '../ui/theme';
 import { k, kc, col, px, usd, shortAddr } from '../lib/format';
 import { exchChipStyle, WALLET_CHIP, ACCOUNT_CHIP, ColorChip, walletLabelOf, accountLabelOf } from '../lib/tags';
-import { distToLiq } from '../lib/pnl';
+import { distToLiq, hasDisplayableLiq } from '../lib/pnl';
 import { lifecycleKey } from '../data/DataSource';
 import { ExitPlanner } from './ExitPlanner';
 import { useIsMobile } from '../lib/useIsMobile';
@@ -406,6 +406,9 @@ function PositionRow({ p, groupNegPL }: { p: Position; groupNegPL: number }) {
   const isMobile = useIsMobile();
   const dist = distToLiq(p);
   const perp = isPerp(p);
+  // Display-only: an unreachably-far cross-margin liq is shown as "—" (matching
+  // the exchange's own FE). The raw p.liq is untouched; risk gating is unaffected.
+  const showLiq = hasDisplayableLiq(p);
 
   // "Has a protective stop" = at least one resting order with action 'Stop loss'
   // (the reduce-only stop for this position).
@@ -493,7 +496,7 @@ function PositionRow({ p, groupNegPL }: { p: Position; groupNegPL: number }) {
           <div style={{ display: 'grid', gridTemplateColumns: isMobile ? 'repeat(2,1fr)' : 'repeat(auto-fit,minmax(110px,1fr))', gap: 12, marginBottom: orders.length ? 12 : 16 }}>
             <Meta label="Entry" v={px(p.entry)} />
             <Meta label="Now" v={px(p.mark)} />
-            <Meta label="Liquidation" v={perp && p.liq ? px(p.liq) : '—'} color={perp && p.liq ? t.amber : undefined} />
+            <Meta label="Liquidation" v={showLiq ? px(p.liq) : '—'} color={showLiq ? t.amber : undefined} />
             <Meta label="Leverage" v={perp && p.lev > 0 ? `${p.lev}×` : '—'} />
             <Meta label="Unrealized" v={k(p.unreal)} color={col(p.unreal)} />
             <Meta label="Realized" v={k(p.realized)} color={col(p.realized)} />

--- a/src/data/DataSource.ts
+++ b/src/data/DataSource.ts
@@ -2,8 +2,8 @@ import type {
   Position, Portfolio, Wallet, OrderLevel, RestingOrder, ActivityEvent, ActivityFilter, ClosedTrade, Account,
   ClosedAgg, ClosedGroupAgg, ClosedWindow, PerfDim, LifecycleMap,
   IncomePeriodRow, IncomeFilter, IncomeGrain,
-  PositionBreakdown, BreakdownTotals, LedgerTotals, PositionEvent, SizeReconcileRow,
-  DriftSnapshot, DriftHolding, PnlDailyRow,
+  LedgerTotals, PositionEvent, SizeReconcileRow,
+  DriftSnapshot, DriftHolding, PnlDailyRow, EventStreamRow, EventFilter,
 } from '../types';
 import type { OmniRawEventInsert } from '../lib/omniCsvParser';
 
@@ -113,23 +113,19 @@ export interface DataSource {
   // header is full period P&L, the list is the positions within the range.
   fetchLedgerTotals(sinceMs: number, untilMs: number): Promise<LedgerTotals>;
 
-  // Grand-total aggregate of the range-scoped breakdown over [since, until] — count + Σ
-  // of the same rows the pages walk. Drives the list Total row + subtitle count.
-  // Reconciles to the header's category cards minus ledger-only events tied to no
-  // position (2026-07-11 range-scope fix, Opt 1).
-  fetchRangeBreakdownTotals(sinceMs: number, untilMs: number): Promise<BreakdownTotals>;
-
-  // One PAGE of the range-scoped per-position breakdown list (2026-07-11 range-scope fix,
-  // Opt 1): positions with a P/L-generating event (realized fill / funding / fee /
-  // interest / reward / hack) in [since, until], each row carrying its IN-RANGE
-  // per-category CONTRIBUTION (Σ of that position's ledger events in the window) — NOT
-  // lifetime. COMPLETE (fully closed) + PARTIAL (open with realized in range), newest
-  // first. Sourced from mat_position_range_breakdown; auto-loaded on 50%-scroll.
-  fetchRangeBreakdown(
-    sinceMs: number,
-    untilMs: number,
-    opts: { limit: number; offset: number },
-  ): Promise<PositionBreakdown[]>;
+  // ── Event-stream drill-down (#256 Stage B) ──────────────────────────────────
+  // The events that SUM TO a clicked breakdown row: agg_event_stream rows within
+  // [sinceDay, untilDay] (inclusive UTC-day bounds on the `day` column) narrowed to
+  // the clicked scope (a bucket type, and/or asset / exch / exchange_account_id).
+  // Each row carries the 6 processor buckets so the client shows each event's
+  // contribution and their Σ (== the breakdown row's total; see eventNet). Bounded
+  // by `limit` (drill scopes are narrow) and newest-first. RLS-scoped by the view.
+  fetchEventStream(
+    sinceDay: string,
+    untilDay: string,
+    filter: EventFilter,
+    limit: number,
+  ): Promise<EventStreamRow[]>;
 
   // ALL contributing events for one position (#223 D: expand a row), ts DESC —
   // every fill/funding/fee/interest/reward/settlement of that position, from

--- a/src/data/apolloSource.ts
+++ b/src/data/apolloSource.ts
@@ -9,7 +9,7 @@ import {
   CLOSED_DISTINCT_EXCH_QUERY, CLOSED_DISTINCT_ASSET_QUERY, CLOSED_DISTINCT_WALLET_QUERY,
   CLOSED_GROUP_AGG_EXCH_QUERY, CLOSED_GROUP_AGG_ASSET_QUERY, CLOSED_GROUP_AGG_WALLET_QUERY,
   INCOME_PERIODS_QUERY,
-  LEDGER_TOTALS_QUERY, RANGE_BREAKDOWN_QUERY, RANGE_BREAKDOWN_TOTALS_QUERY, POSITION_EVENTS_QUERY,
+  LEDGER_TOTALS_QUERY, EVENT_STREAM_QUERY, POSITION_EVENTS_QUERY,
   UPSERT_ORDER_LEVEL, ADD_ORDER_LEVEL, REMOVE_ORDER_LEVEL, SET_WALLET_LABEL,
   UPDATE_ACCOUNT_LABEL, UPDATE_ACCOUNT_TAGS,
   INSERT_OMNI_RAW_EVENTS,
@@ -17,12 +17,13 @@ import {
   DRIFT_SNAPSHOTS_QUERY, UPSERT_DRIFT_SNAPSHOT, DRIFT_HACKDAY_TS,
   PNL_DAILY_QUERY,
 } from '../graphql/operations';
+import { EVENT_BUCKET_COLUMN } from '../lib/pnlDaily';
 import type {
   Position, Portfolio, Wallet, OrderLevel, RestingOrder, ActivityEvent, ActivityFilter, ClosedTrade, Account, Exchange, Accuracy, ReconcileStatus, Side,
   ClosedAgg, ClosedGroupAgg, ClosedWindow, PerfDim, Lifecycle, LifecycleMap,
   IncomePeriodRow, IncomeFilter, IncomeGrain, IncomeCategory,
-  PositionBreakdown, BreakdownTotals, LedgerTotals, PositionEvent, SizeReconcileRow,
-  DriftSnapshot, DriftHolding, PnlDailyRow,
+  LedgerTotals, PositionEvent, SizeReconcileRow,
+  DriftSnapshot, DriftHolding, PnlDailyRow, EventStreamRow, EventFilter,
 } from '../types';
 import type { OmniRawEventInsert } from '../lib/omniCsvParser';
 import { shortAddr } from '../lib/format';
@@ -313,45 +314,31 @@ const mapClosedTrade = (r: any): ClosedTrade => {
   };
 };
 
-// ── per-position breakdown (#223 Analytics rebuild) ──────────────────────────
-// mat_position_breakdown row → domain PositionBreakdown. Columns are already 1:1
-// with the type; we only coerce numerics + resolve the per-user wallet label off
-// the exchange_account→wallet→user_wallets chain (RLS-scoped, ≤1 row). The 7 money
-// fields are the DB's already-reconciled buckets — NO client money math.
-const mapBreakdown = (r: any): PositionBreakdown => ({
+// ── event-stream drill-down (#256 Stage B) ───────────────────────────────────
+// agg_event_stream row → domain EventStreamRow (#256 drill-down). The 6 buckets are
+// the DB's already-reconciled per-event decomposition — NO client money math; the
+// signed net (with fee subtracted) is derived where rendered (lib/pnlDaily.eventNet).
+const mapEventStreamRow = (r: any): EventStreamRow => ({
   id: r.id,
+  eventId: r.event_id,
+  day: r.day,
+  createdMs: r.created_at ? Date.parse(r.created_at) : 0,
+  eventType: (r.event_type as string | undefined)?.trim() ?? '',
+  direction: (r.direction as string | undefined)?.trim() ?? '',
+  quantity: num(r.quantity),
   asset: r.asset ?? '',
+  marketType: (r.market_type as string | undefined) ?? '',
   exch: (r.exch as string | undefined)?.trim() ?? '',
-  wallet: (r.account as string | undefined)?.trim() ?? '',
-  walletLabel: (r.exchange_account?.wallet?.user_wallets?.[0]?.label as string | undefined)?.trim() ?? '',
-  isPartial: !!r.is_partial,
-  earliestEventMs: num(r.earliest_event_ts),
-  lastEventMs: num(r.last_event_ts),
-  netPnl: num(r.net_pnl),
+  accountLabel: (r.account_label as string | undefined)?.trim() ?? '',
+  exchangeAccountId: r.exchange_account_id,
+  status: (r.status as string | undefined)?.trim() ?? '',
   tradePnl: num(r.trade_pnl),
-  funding: num(r.funding),
-  fees: num(r.fees),
-  interest: num(r.interest),
-  rewards: num(r.rewards),
-  hacks: num(r.hacks),
+  fundingPnl: num(r.funding_pnl),
+  feePnl: num(r.fee_pnl), // POSITIVE-COST magnitude — negated only when netted (eventNet)
+  interestPnl: num(r.interest_pnl),
+  rewardPnl: num(r.reward_pnl),
+  hackPnl: num(r.hack_pnl),
 });
-
-// mat_position_range_breakdown_aggregate { aggregate { count sum {...} } } → BreakdownTotals.
-// The Σ over the whole in-range set — NOT client money math, the DB aggregates the same
-// range-scoped per-position buckets the pages walk.
-const mapBreakdownTotals = (agg: any): BreakdownTotals => {
-  const s = agg?.sum ?? {};
-  return {
-    count: num(agg?.count),
-    netPnl: num(s.net_pnl),
-    tradePnl: num(s.trade_pnl),
-    funding: num(s.funding),
-    fees: num(s.fees),
-    interest: num(s.interest),
-    rewards: num(s.rewards),
-    hacks: num(s.hacks),
-  };
-};
 
 // LEDGER_TOTALS_QUERY result → LedgerTotals (#228). Each aliased aggregate is that
 // category's SUM(amount) over the window (already signed USD). Net = Σ INCOME cats
@@ -850,30 +837,24 @@ export function makeApolloDataSource(client: ApolloClient<any>): DataSource {
       return mapLedgerTotals(data);
     },
 
-    // Grand-total aggregate over the whole in-range set (count + Σ) — drives the list
-    // Total row + subtitle. 'network-only' — always fresh. Reconciles to the header's
-    // category cards minus ledger-only events tied to no position.
-    fetchRangeBreakdownTotals: async (sinceMs, untilMs): Promise<BreakdownTotals> => {
+    // ── Event-stream drill-down (#256 Stage B) ────────────────────────────────
+    // The events that sum to a clicked breakdown row. Builds the agg_event_stream
+    // `where` from the day bounds + the clicked scope (bucket / asset / exch /
+    // account). 'no-cache' — drill scopes vary, the payload is transient (copied
+    // straight into component state) and never read back from the cache, so skip
+    // normalization (same reasoning as fetchPnlDaily).
+    fetchEventStream: async (sinceDay, untilDay, filter, limit): Promise<EventStreamRow[]> => {
+      const and: any[] = [{ day: { _gte: sinceDay, _lte: untilDay } }];
+      if (filter.bucket) and.push({ [EVENT_BUCKET_COLUMN[filter.bucket]]: { _neq: 0 } });
+      if (filter.asset !== undefined) and.push({ asset: { _eq: filter.asset } });
+      if (filter.exch !== undefined) and.push({ exch: { _eq: filter.exch } });
+      if (filter.accountId !== undefined) and.push({ exchange_account_id: { _eq: filter.accountId } });
       const { data } = await client.query({
-        query: RANGE_BREAKDOWN_TOTALS_QUERY,
-        variables: { since: Math.floor(sinceMs), until: Math.floor(untilMs) },
-        fetchPolicy: 'network-only',
-      });
-      return mapBreakdownTotals(data?.mat_position_range_breakdown_aggregate?.aggregate);
-    },
-
-    // One PAGE of the range-scoped breakdown list (last in-range event DESC, id tiebreak).
-    // Each row carries its IN-RANGE per-category contribution. The caller bumps offset for
-    // the 50%-scroll prefetch. 'no-cache' so re-selecting a window always reflects the
-    // latest data and never collides in the normalized cache.
-    fetchRangeBreakdown: async (sinceMs, untilMs, opts): Promise<PositionBreakdown[]> => {
-      const { limit, offset } = opts;
-      const { data } = await client.query({
-        query: RANGE_BREAKDOWN_QUERY,
-        variables: { since: Math.floor(sinceMs), until: Math.floor(untilMs), limit, offset },
+        query: EVENT_STREAM_QUERY,
+        variables: { where: { _and: and }, limit },
         fetchPolicy: 'no-cache',
       });
-      return ((data?.position_breakdown as any[]) ?? []).map(mapBreakdown);
+      return ((data?.agg_event_stream as any[]) ?? []).map(mapEventStreamRow);
     },
 
     // ALL contributing events for one position (ts DESC) — the expand-row detail.

--- a/src/data/mockEngine.ts
+++ b/src/data/mockEngine.ts
@@ -5,7 +5,7 @@ import type {
   Position, Portfolio, Wallet, OrderLevel, RestingOrder, ActivityEvent, ActivityFilter, ClosedTrade, Account,
   ClosedAgg, ClosedGroupAgg, PerfDim,
   IncomePeriodRow, IncomeFilter, IncomeGrain, IncomeCategory, LedgerTotals,
-  DriftSnapshot, PnlDailyRow,
+  DriftSnapshot, PnlDailyRow, EventStreamRow, EventFilter, PnlComponent,
 } from '../types';
 import type { OmniRawEventInsert } from '../lib/omniCsvParser';
 import { pnlAt } from '../lib/pnl';
@@ -460,36 +460,45 @@ export class MockEngine {
         return acc;
       },
 
-      // ── Range breakdown (2026-07-11 range-scope fix) mock parity ──────────────
-      // Positions with a P/L event in the window — the SAME shape the live
-      // mat_position_range_breakdown function returns. Mock seeds are all COMPLETE
-      // (no partial-close seed data). Totals aggregate + paginated page, so the list
-      // Total (from the aggregate) == the pages' Σ.
-      fetchRangeBreakdownTotals: async (sinceMs, untilMs) => {
-        const inWin = seedClosedTrades.filter((t) => t.closedMs >= sinceMs && t.closedMs <= untilMs);
-        const acc = { count: 0, netPnl: 0, tradePnl: 0, funding: 0, fees: 0, interest: 0, rewards: 0, hacks: 0 };
-        for (const t of inWin) {
-          acc.count += 1;
-          acc.netPnl += t.total; acc.tradePnl += t.pnl; acc.funding += t.funding;
-          acc.fees += t.fees; acc.interest += t.interest; acc.rewards += t.rewards; acc.hacks += t.hack;
-        }
-        return acc;
-      },
-
-      fetchRangeBreakdown: async (sinceMs, untilMs, opts) => {
-        const { limit, offset } = opts;
-        return seedClosedTrades
-          .filter((t) => t.closedMs >= sinceMs && t.closedMs <= untilMs)
-          .slice()
-          .sort((a, b) => (b.closedMs - a.closedMs) || a.id.localeCompare(b.id))
-          .slice(offset, offset + limit)
-          .map((t) => ({
-            id: t.id, asset: t.asset, exch: t.exch, wallet: t.wallet, walletLabel: t.walletLabel,
-            isPartial: false,
-            earliestEventMs: t.closedMs - t.dur * 86_400_000,
-            lastEventMs: t.closedMs,
-            netPnl: t.total, tradePnl: t.pnl, funding: t.funding, fees: t.fees,
-            interest: t.interest, rewards: t.rewards, hacks: t.hack,
+      // ── Event-stream drill-down (#256) mock parity ────────────────────────────
+      // Synthesize ONE event per in-range daily-rollup row (carrying all 6 buckets),
+      // then narrow to the clicked scope. net(events) == Σ totalPnl over the scope, so
+      // the drill visibly sums to the breakdown row exactly as the live view does.
+      // (mock feePnl is the SIGNED contribution (negative); EventStreamRow.feePnl is the
+      // POSITIVE-COST magnitude, so we store −feePnl — mirrors the live column.)
+      fetchEventStream: async (sinceDay: string, untilDay: string, filter: EventFilter, limit: number): Promise<EventStreamRow[]> => {
+        const bucketField: Record<PnlComponent, keyof PnlDailyRow> = {
+          tradePnl: 'tradePnl', fundingPnl: 'fundingPnl', feePnl: 'feePnl',
+          interestPnl: 'interestPnl', rewardPnl: 'rewardPnl', hackPnl: 'hackPnl',
+        };
+        return this.pnlDailyHistory()
+          .filter((r) => r.day >= sinceDay && r.day <= untilDay)
+          .filter((r) => (filter.asset === undefined || r.asset === filter.asset)
+            && (filter.exch === undefined || r.exch === filter.exch)
+            && (filter.accountId === undefined || r.exchangeAccountId === filter.accountId)
+            && (filter.bucket === undefined || r[bucketField[filter.bucket]] !== 0))
+          .sort((a, b) => (a.day < b.day ? 1 : a.day > b.day ? -1 : 0))
+          .slice(0, limit)
+          .map((r) => ({
+            id: `evt-${r.id}`,
+            eventId: `evt-${r.id}`,
+            day: r.day,
+            createdMs: Date.parse(r.day + 'T00:00:00Z'),
+            eventType: r.tradePnl !== 0 ? 'trade' : r.fundingPnl !== 0 ? 'funding' : r.hackPnl !== 0 ? 'hack' : 'accrual',
+            direction: r.tradePnl >= 0 ? 'buy' : 'sell',
+            quantity: 0,
+            asset: r.asset,
+            marketType: r.marketType,
+            exch: r.exch,
+            accountLabel: r.accountLabel,
+            exchangeAccountId: r.exchangeAccountId,
+            status: 'closed',
+            tradePnl: r.tradePnl,
+            fundingPnl: r.fundingPnl,
+            feePnl: -r.feePnl, // signed contribution → positive-cost magnitude
+            interestPnl: r.interestPnl,
+            rewardPnl: r.rewardPnl,
+            hackPnl: r.hackPnl,
           }));
       },
 

--- a/src/data/perfWindow.ts
+++ b/src/data/perfWindow.ts
@@ -15,14 +15,13 @@ import type { Timeframe, WinBounds } from '../types';
 
 const DAY_MS = 86_400_000;
 
-// Look-back (days) for each short window. Mirrors the old CUT map so behaviour is
-// unchanged except the anchor is now real-now instead of the frozen constant.
+// Look-back (days) for the rolling fallback windows. day/week/month are NO LONGER
+// resolved from this map — they are CALENDAR-aligned below (#263) so the header
+// window matches the over-time chart's calendar bucket exactly. This map now only
+// backs `hour` (and any unknown win), which stay rolling.
 //   hour ≈ 0.05d (72m) matches the old CUT['hour'].
 const LOOKBACK_DAYS: Record<string, number> = {
   hour: 0.05,
-  day: 1,
-  week: 7,
-  month: 31,
 };
 
 /** True when `win` is a 4-digit calendar year string like '2025'. */
@@ -33,9 +32,20 @@ export const isYearWin = (win: string): boolean => /^\d{4}$/.test(win);
  *   - year 'YYYY' : the whole calendar year (UTC).
  *   - 'ytd'       : Jan 1 of the current UTC year → now.
  *   - 'all'       : from 0 → now (effectively unbounded lower).
- *   - short win   : now - lookback → now.
+ *   - 'month'     : first of the current UTC month → now  (CALENDAR, #263).
+ *   - 'week'      : start of the current ISO week (Monday, UTC) → now (#263).
+ *   - 'day'       : start of today UTC → now  (CALENDAR, #263).
+ *   - other short : now - lookback → now  (rolling; only `hour` today).
  * `until` is always `now` for non-year windows (mat_closed_trades has no future
  * rows, but the explicit upper bound keeps the aggregate + list windows identical).
+ *
+ * #263: day/week/month were previously ROLLING trailing-N-day windows (1/7/31d),
+ * but the Analytics header labels them "today / this week / this month" and the
+ * over-time chart buckets by CALENDAR period (lib/pnlDaily.ts `bucketStart`). A
+ * trailing-31-day sum disagreed with the chart's calendar-month bar. These three
+ * are now calendar-aligned to the SAME boundary convention `bucketStart` uses —
+ * month = first of month, week = ISO Monday-start (UTC), day = midnight UTC — so
+ * the header window == the current (latest) chart bar exactly.
  */
 export function windowBounds(win: Timeframe, now: number = Date.now()): WinBounds {
   if (isYearWin(win)) {
@@ -52,6 +62,25 @@ export function windowBounds(win: Timeframe, now: number = Date.now()): WinBound
   if (win === 'all') {
     return { sinceMs: 0, untilMs: now };
   }
-  const days = LOOKBACK_DAYS[win] ?? LOOKBACK_DAYS.day;
+  // Calendar-aligned short windows (#263). Boundaries match lib/pnlDaily.ts
+  // `bucketStart`: month = first of month; week = ISO Monday-start; day = midnight,
+  // all in UTC.
+  const d = new Date(now);
+  const y = d.getUTCFullYear();
+  const mo = d.getUTCMonth();
+  const dom = d.getUTCDate();
+  if (win === 'month') {
+    return { sinceMs: Date.UTC(y, mo, 1), untilMs: now };
+  }
+  if (win === 'week') {
+    // dow: 0 = Monday … 6 = Sunday (matches bucketStart's `(getUTCDay()+6)%7`).
+    const dow = (d.getUTCDay() + 6) % 7;
+    return { sinceMs: Date.UTC(y, mo, dom) - dow * DAY_MS, untilMs: now };
+  }
+  if (win === 'day') {
+    return { sinceMs: Date.UTC(y, mo, dom), untilMs: now };
+  }
+  // Rolling fallback (hour / unknown wins) — trailing lookback from real-now.
+  const days = LOOKBACK_DAYS[win] ?? 1;
   return { sinceMs: Math.floor(now - days * DAY_MS), untilMs: now };
 }

--- a/src/graphql/operations.ts
+++ b/src/graphql/operations.ts
@@ -586,102 +586,46 @@ export const CLOSED_WINDOW_QUERY = gql`
 `;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// PER-POSITION RANGE BREAKDOWN  (Analytics list — 2026-07-11 range-scope fix, Opt 1).
+// EVENT STREAM DRILL-DOWN  (#256 Stage B — the unified breakdown's "click a row to
+// see the events that sum to it").
 //
-// THE BUG THIS FIXES: the old list read `mat_position_breakdown` (LIFETIME per-position
-// buckets) merely FILTERED by last_event_ts. So at 1hr an open position whose last
-// funding tick landed in the window rendered its FULL-LIFE realized P/L (e.g. TAO
-// +$9.4K) and the Total row showed +$19.5K — flatly contradicting the ~$0 range header.
+// Source: `agg_event_stream` — the per-event decomposition view. Each row is ONE
+// contributing event carrying the 6 processor PnL buckets (trade / funding / fee /
+// interest / reward / hack) from position_event_pnl, plus its type / direction /
+// quantity / asset / market_type / account labels / position status. The buckets
+// obey the SAME sign convention as agg_pnl_daily (fee_pnl is a POSITIVE COST the
+// total SUBTRACTS), so an event's net contribution is
+//   trade + funding − fee + interest + reward + hack
+// and SUM(net) over a scope EXACTLY equals that scope's agg_pnl_daily total (verified
+// against prod: asset / exch / account group keys reconcile 0-mismatch). RLS-scoped
+// to the user via exchange_account → wallet → user_wallets → user_id.
 //
-// THE FIX (realized-only): the list is now sourced from the SQL function
-// `mat_position_range_breakdown(p_since, p_until)` which GROUPs the categorized money
-// ledger BY POSITION over [since, until]. Each row is that position's CONTRIBUTION
-// WITHIN THE RANGE — Σ of its ledger events (realized fill / funding / fee / interest /
-// reward / hack) whose ts ∈ [since, until]. A position with no in-range P/L event does
-// NOT appear (1hr with no activity → empty). earliest/last_event_ts are the in-range
-// min/max event ts (NOT the lifetime span).
-//
-// WHY IT RECONCILES TO THE HEADER: the function's per-category sums come from the SAME
-// rows the header sums (`mat_ledger`, category by category) — internally via
-// `mat_position_ledger` (= mat_ledger + a derived position_id, no fan-out). So
-//   Σ(list, category C over range) == Σ(mat_ledger, C over range) − (unattributed C rows)
-// where "unattributed" = ledger-only events tied to no position (the −$342,670 Drift
-// hack, standalone income). That documented remainder is the ONLY legitimate gap between
-// the list Total and the header cards; the footnote explains it.
-//
-// RETURNS SETOF mat_position_breakdown → identical column shape (mapBreakdown reused) and
-// INHERITS mat_position_breakdown's user RLS (exchange_account.wallet.user_wallets.user_id
-// = X-Hasura-User-Id) — verified served under X-Hasura-Role: user. Hasura exposes it as a
-// queryable set (where/order_by/limit/offset) PLUS a `_aggregate` field:
-//   1. PAGE     — mat_position_range_breakdown(args, order_by last_event_ts desc, limit,
-//                 offset): one 50-row page, auto-loaded on 50%-scroll (small payload).
-//   2. TOTALS   — mat_position_range_breakdown_aggregate(args): count + Σ over ALL the
-//                 user's in-range positions in ONE round-trip. The list Total row reads
-//                 THIS (the whole in-range set), so it reconciles to the header's
-//                 category cards minus ledger-only events tied to no position.
-// (We paginate server-side + total via the aggregate — NOT a full pull — because a heavy
-// book has ~1k in-range positions; an all-rows fetch was a 400KB/5s payload.)
-// ─────────────────────────────────────────────────────────────────────────────
-
-// Shared selection set — matches the PositionBreakdown mapper 1:1.
-const BREAKDOWN_FIELDS = `
-  id
-  asset
-  exch
-  account
-  is_partial
-  earliest_event_ts
-  last_event_ts
-  net_pnl
-  trade_pnl
-  funding
-  fees
-  interest
-  rewards
-  hacks
-  exchange_account {
-    wallet {
-      user_wallets {
-        label
-      }
-    }
-  }
-`;
-
-// One PAGE of the range breakdown list (last in-range event DESC, id tiebreak) — positions
-// with a P/L-generating event in [since, until], each carrying its in-range per-category
-// contribution. Auto-loaded on 50%-scroll; the caller bumps offset.
-export const RANGE_BREAKDOWN_QUERY = gql`
-  query RangeBreakdown($since: bigint!, $until: bigint!, $limit: Int!, $offset: Int!) {
-    position_breakdown: mat_position_range_breakdown(
-      args: { p_since: $since, p_until: $until }
-      order_by: [{ last_event_ts: desc }, { id: desc }]
-      limit: $limit
-      offset: $offset
-    ) {
-      ${BREAKDOWN_FIELDS}
-    }
-  }
-`;
-
-// Grand-total aggregate over the WHOLE in-range set — drives the list Total row + the
-// subtitle position count. count + Σ of the same rows the pages walk. Reconciles to the
-// header's category cards minus ledger-only events tied to no position.
-export const RANGE_BREAKDOWN_TOTALS_QUERY = gql`
-  query RangeBreakdownTotals($since: bigint!, $until: bigint!) {
-    mat_position_range_breakdown_aggregate(args: { p_since: $since, p_until: $until }) {
-      aggregate {
-        count
-        sum {
-          net_pnl
-          trade_pnl
-          funding
-          fees
-          interest
-          rewards
-          hacks
-        }
-      }
+// The caller passes a fully-built `where` (day bounds + the clicked scope: an asset /
+// exch / exchange_account_id equality, and/or a single bucket `_neq 0` for a by-type
+// row). Bounded by `limit` (drill scopes are narrow; a hit limit shows a "partial sum"
+// note client-side) and ordered newest-first.
+export const EVENT_STREAM_QUERY = gql`
+  query EventStream($where: agg_event_stream_bool_exp!, $limit: Int!) {
+    agg_event_stream(where: $where, order_by: { created_at: desc }, limit: $limit) {
+      id
+      event_id
+      day
+      created_at
+      event_type
+      direction
+      quantity
+      asset
+      market_type
+      exch
+      account_label
+      exchange_account_id
+      status
+      trade_pnl
+      funding_pnl
+      fee_pnl
+      interest_pnl
+      reward_pnl
+      hack_pnl
     }
   }
 `;
@@ -962,9 +906,16 @@ export const UPSERT_DRIFT_SNAPSHOT = gql`
 // RLS-scoped via exchange_account → wallet → user_wallets → user (same path as
 // mat_positions).
 // ─────────────────────────────────────────────────────────────────────────────
+//
+// STAGE B (#256) REPOINT: the source is now `agg_pnl_daily` (the read-time view
+// the analytics-consolidation work canonicalised — identical column shape to the
+// old mat_pnl_daily, ties to the money identity). We keep the response KEY as
+// `mat_pnl_daily` via a GraphQL field ALIAS so apolloSource (`data.mat_pnl_daily`)
+// and the reallogin QA gate (which reads `data.mat_pnl_daily`) are untouched, and
+// the operationName stays `PnlDaily` (the gate matches on it).
 export const PNL_DAILY_QUERY = gql`
   query PnlDaily($since: date!, $until: date!) {
-    mat_pnl_daily(
+    mat_pnl_daily: agg_pnl_daily(
       where: { day: { _gte: $since, _lte: $until } }
       order_by: { day: asc }
     ) {

--- a/src/lib/pnl.ts
+++ b/src/lib/pnl.ts
@@ -11,6 +11,31 @@ export function distToLiq(p: Position): number {
   return Math.abs((p.liq - p.mark) / p.mark) * 100;
 }
 
+/**
+ * Cross-margin "unreachable liq" cutoff (fraction of mark). A liquidation price
+ * more than FAR_LIQ_FRAC×mark away from mark means the position is so
+ * over-collateralised that liquidation is economically unreachable — the
+ * exchange's own FE shows "—" while the API still returns a degenerate far value
+ * (e.g. Lighter ARB SHORT: mark 0.0897, liq 28.15 ≈ 313× away). 10 = 1000% away;
+ * cleanly separates that from a real deep liq (e.g. AVAX ≈ 0.89× away).
+ */
+export const FAR_LIQ_FRAC = 10;
+
+/**
+ * DISPLAY-ONLY: true when a perp's liquidation price is present AND close enough
+ * to mark to be economically meaningful — i.e. worth SHOWING as a number. When
+ * false we render "—" instead of the raw far value. This does NOT change the
+ * stored/mirrored liq, nor the near-liq/risk gating (those already require the
+ * liq be within 10% of mark, so a far liq never trips them).
+ */
+export function hasDisplayableLiq(p: Position): boolean {
+  return (
+    p.type?.toLowerCase() === 'perp' &&
+    p.liq > 0 &&
+    Math.abs(p.liq - p.mark) / p.mark <= FAR_LIQ_FRAC
+  );
+}
+
 export function likelihood(distPct: number): { label: string; color: string } {
   if (distPct < 6) return { label: 'Very likely', color: '#f87171' };
   if (distPct < 12) return { label: 'Likely', color: '#fbbf24' };

--- a/src/lib/pnlDaily.ts
+++ b/src/lib/pnlDaily.ts
@@ -7,7 +7,7 @@
 // (#196) is exactly what this file structurally prevents: every breakdown is a
 // GROUP BY over one identical row set, so a breakdown can never disagree with the
 // total (Σ of any grouping == Σ of any other grouping == the grand total).
-import type { PnlComponent, PnlDailyRow, PnlGranularity, PnlGroupBy } from '../types';
+import type { EventStreamRow, PnlComponent, PnlDailyRow, PnlGranularity, PnlGroupBy } from '../types';
 
 // Component display order — matches Jaison's spec verbatim: "trade pnl ... funding,
 // rewards, interest ... hacks, fee[s]". One chip per component; the
@@ -50,6 +50,33 @@ export function sumTotals(rows: PnlDailyRow[]): ComponentTotals {
   for (const r of rows) addInto(acc, r);
   return acc;
 }
+
+// ── event-stream drill-down helpers (#256) ───────────────────────────────────
+// The agg_event_stream columns use the SAME sign convention as agg_pnl_daily:
+// feePnl is a POSITIVE-COST magnitude the total SUBTRACTS. So an event's SIGNED
+// net contribution is trade + funding − fee + interest + reward + hack — identical
+// to totalPnl's identity — and SUM(net) over a scope equals that scope's
+// agg_pnl_daily total exactly (the "visibly sums to it" guarantee).
+export function eventNet(e: EventStreamRow): number {
+  return e.tradePnl + e.fundingPnl - e.feePnl + e.interestPnl + e.rewardPnl + e.hackPnl;
+}
+
+// One event's SIGNED contribution to a single bucket (fees negated, everything
+// else pass-through) — the value shown when a by-TYPE breakdown row is drilled.
+export function eventContribution(e: EventStreamRow, comp: PnlComponent): number {
+  return comp === 'feePnl' ? -e.feePnl : e[comp];
+}
+
+// The agg_event_stream column each PnlComponent maps to — used to build the
+// `<col> _neq 0` where clause that restricts a by-TYPE drill to contributing events.
+export const EVENT_BUCKET_COLUMN: Record<PnlComponent, string> = {
+  tradePnl: 'trade_pnl',
+  fundingPnl: 'funding_pnl',
+  feePnl: 'fee_pnl',
+  interestPnl: 'interest_pnl',
+  rewardPnl: 'reward_pnl',
+  hackPnl: 'hack_pnl',
+};
 
 // ── granularity bucketing ────────────────────────────────────────────────────
 // `day` is already a UTC date string 'YYYY-MM-DD' (the grain is the EVENT's UTC

--- a/src/lib/series.ts
+++ b/src/lib/series.ts
@@ -1,4 +1,5 @@
 import type { Position } from '../types';
+import { hasDisplayableLiq } from './pnl';
 
 export interface Candle { o: number; h: number; l: number; c: number; v: number; }
 
@@ -33,7 +34,9 @@ export function getSeries(p: Position): Candle[] {
 /** Price range for the exit-planner ladder, based only on real position prices. */
 export function priceBounds(p: Position): { mn: number; mx: number } {
   const candidates = [p.entry, p.mark];
-  if (p.liq > 0) candidates.push(p.liq);
+  // Only fold a DISPLAYABLE liq into the y-range — an unreachably-far cross-margin
+  // liq would otherwise blow the exit-planner scale out by hundreds of ×.
+  if (hasDisplayableLiq(p)) candidates.push(p.liq);
   let mn = Math.min(...candidates), mx = Math.max(...candidates);
   // Ensure a visible range even if entry ≈ mark (e.g. just opened)
   const spread = mx - mn || p.mark * 0.05;

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,44 +285,6 @@ export interface Wallet {
 }
 
 // ── Per-position breakdown (#223 Analytics rebuild) ──────────────────────────
-// One row of `mat_position_breakdown`: a per-position PnL rollup (source:
-// position_pnl buckets, SAME sign convention as mat_closed_trades). Covers
-// fully-closed positions AND still-OPEN positions with realized PnL from partial
-// closes (isPartial). All ts are epoch-ms. The 7 money fields are already-
-// reconciled buckets — NO new client money math (net = the DB's net_pnl). The
-// Analytics header SUMs these same rows, so header totals == list Σ to the cent.
-export interface PositionBreakdown {
-  id: string;
-  asset: string;
-  exch: string;         // exchanges.display_name
-  wallet: string;       // account label (exchange_accounts.label)
-  walletLabel: string;  // per-user wallet label (user_wallets.label); '' if unset
-  isPartial: boolean;   // true = OPEN position with realized (partial close); false = COMPLETE
-  earliestEventMs: number; // min contributing-event ts (epoch-ms)
-  lastEventMs: number;     // close / max-event ts (epoch-ms) — the sort key (DESC)
-  netPnl: number;
-  tradePnl: number;
-  funding: number;
-  fees: number;
-  interest: number;
-  rewards: number;
-  hacks: number;
-}
-
-// Grand-total aggregate of mat_position_breakdown over a window (drives the
-// Analytics header cards). The SUMs are the already-reconciled per-position
-// buckets — net == Σ netPnl. `count` = positions folded in.
-export interface BreakdownTotals {
-  count: number;
-  netPnl: number;
-  tradePnl: number;
-  funding: number;
-  fees: number;
-  interest: number;
-  rewards: number;
-  hacks: number;
-}
-
 // ── Analytics header totals (#228) ────────────────────────────────────────────
 // The 7-card header sums the FULL LEDGER (mat_ledger) over the selected range —
 // the TRUE period P&L per category — NOT the per-position breakdown. This picks up
@@ -442,6 +404,47 @@ export type PnlComponent =
   | 'tradePnl' | 'fundingPnl' | 'feePnl' | 'interestPnl' | 'rewardPnl' | 'hackPnl';
 export type PnlGranularity = 'day' | 'week' | 'month' | 'year';
 export type PnlGroupBy = 'none' | 'asset' | 'exch' | 'account';
+
+// ── Event-stream drill-down (#256 Stage B) ────────────────────────────────────
+// One row of `agg_event_stream`: a single contributing event, carrying the 6
+// processor PnL buckets. The buckets follow the SAME sign convention as
+// PnlDailyRow — feePnl is the POSITIVE-COST magnitude, so the event's signed net
+// contribution is trade + funding − fee + interest + reward + hack (see
+// eventNet() in lib/pnlDaily.ts). SUM(net) over a scope EXACTLY equals that scope's
+// agg_pnl_daily total, which is what lets the drill-down "visibly sum to" the
+// breakdown row the user clicked.
+export interface EventStreamRow {
+  id: string;
+  eventId: string;
+  day: string;            // UTC day 'YYYY-MM-DD'
+  createdMs: number;      // event time (epoch-ms, from created_at)
+  eventType: string;      // trade / funding / fee / interest / reward / hack / …
+  direction: string;      // buy / sell / … ('' when N/A)
+  quantity: number;
+  asset: string;
+  marketType: string;     // spot / perp / pool
+  exch: string;
+  accountLabel: string;
+  exchangeAccountId: string;
+  status: string;         // owning position status (open / closed)
+  tradePnl: number;
+  fundingPnl: number;
+  feePnl: number;         // POSITIVE COST magnitude (subtracted in net)
+  interestPnl: number;
+  rewardPnl: number;
+  hackPnl: number;
+}
+
+// Server-side filter for the event-stream drill-down (#256). The caller sets the
+// clicked scope; apolloSource folds it into the agg_event_stream `where` alongside
+// the day bounds. All fields optional — a by-TYPE row sets `bucket`; a group row
+// sets asset / exch / accountId. Multiple set fields AND together.
+export interface EventFilter {
+  bucket?: PnlComponent;  // restrict to events contributing to this bucket (<col> _neq 0)
+  asset?: string;         // asset _eq
+  exch?: string;          // exch _eq
+  accountId?: string;     // exchange_account_id _eq
+}
 
 // Short windows + calendar year strings ('2023', '2024', …). Year values are
 // validated at store-init by checking they're 4-digit numeric strings.


### PR DESCRIPTION
Fast-forward layering of the post-07-15 FE fixes (#256 agg views, #263 calendar windows, #264 far-liq render) on top of the consolidated main. Resulting tree is byte-identical to the running live bundle index-CbtTyiBL. Part of #171 untangle.