### PR TITLE
fix(#198): gate prod build on tsc + clear leaked toast timers

### DIFF
--- a/build-prod.sh
+++ b/build-prod.sh
@@ -16,6 +16,14 @@ OUT_DIR="${OUT_DIR:-dist.new}"
 
 cd "$SCRIPT_DIR"
 
+# #198: the production build MUST gate on the typechecker. `vite build` uses
+# esbuild, which strips types WITHOUT checking them — so a build that only ran
+# `vite build` shipped whether or not `tsc` passed. Run `tsc -b` first and let
+# `set -e` abort the whole build on any type error (identical gate to the
+# committed `npm run build` = `tsc -b && vite build` recipe).
+echo "▶ Typechecking (tsc -b — build gates on this)..."
+npx --yes tsc -b
+
 echo "▶ Building zif-app (production) → ${OUT_DIR}/"
 npx --yes vite build \
   --mode production \

--- a/src/hooks/useLiveTradeToasts.ts
+++ b/src/hooks/useLiveTradeToasts.ts
@@ -46,6 +46,12 @@ export function useLiveTradeToasts(): [TradeToast[], (id: string) => void] {
 
   useEffect(() => {
     const cursor = mountTs.current;
+    // Auto-dismiss timers are scheduled inside the subscription callback below.
+    // Track their handles so the effect cleanup can clear any still-pending ones
+    // on unmount — otherwise a toast that arrived just before unmount leaks a
+    // setTimeout that fires setToasts on a torn-down component (#194 follow-up:
+    // cleanup lifted into the effect body).
+    const timers = new Set<ReturnType<typeof setTimeout>>();
 
     const unsub = dataSource.subscribeActivity(cursor, (rows: ActivityEvent[]) => {
       const fresh: TradeToast[] = [];
@@ -70,14 +76,22 @@ export function useLiveTradeToasts(): [TradeToast[], (id: string) => void] {
         return next;
       });
 
-      // Schedule auto-dismiss for each new toast.
+      // Schedule auto-dismiss for each new toast, tracking each handle so a
+      // pending timer can be cleared on unmount (and self-evicting from the set
+      // once it fires so the set doesn't grow unbounded over a long session).
       for (const t of fresh) {
-        setTimeout(() => dismiss(t.id), DISMISS_MS);
+        const handle = setTimeout(() => {
+          timers.delete(handle);
+          dismiss(t.id);
+        }, DISMISS_MS);
+        timers.add(handle);
       }
     });
 
     return () => {
       unsub();
+      for (const handle of timers) clearTimeout(handle);
+      timers.clear();
     };
   }, [dismiss]);
 


### PR DESCRIPTION
## #198 — build must gate on typecheck

### Problem
The committed deploy recipe `build-prod.sh` ran `npx vite build` directly. Vite/esbuild **strips types without checking them**, so the production bundle shipped whether or not `tsc` passed — the `tsc -b && vite build` gate that `npm run build` enforces was silently bypassed by the deploy path.

### Fix
- **`build-prod.sh`**: add an explicit `tsc -b` step before `vite build`. Under `set -e` any type error aborts the whole build. Verified: injecting a type error stops the run at the typecheck step and **no `dist` is produced** (`vite build` never runs).
- `tsc -b` already passes clean on the current tree (the historical `apolloSource.ts` implicit-any errors were resolved upstream); this change makes a regression *fail the build* instead of shipping.

### Also: leaked setTimeout (#194 follow-up)
The live-trade-toast auto-dismiss timers were scheduled inside the subscription callback but never cleared. A toast arriving just before unmount left a `setTimeout` that fired `setToasts` on a torn-down component. Now each handle is tracked and the pending ones are cleared in the effect cleanup (**cleanup lifted into the effect body**); fired timers self-evict so the set can't grow unbounded.

### Verification
- `tsc -b` → clean (exit 0)
- `OUT_DIR=dist.verify bash build-prod.sh` → typecheck passes, live bundle built, `wss://zif-prod.tail5171c8.ts.net/v1/graphql` confirmed present
- Negative test: temporary type error → build aborts before `vite build`, no dist

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww1rWnKu1dcfkK57i1UmGu