### PR TITLE
fix(#199): auto-reload tab on stale-chunk / failed-dynamic-import fetch

### DIFF
--- a/src/lib/chunkReload.test.ts
+++ b/src/lib/chunkReload.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { isChunkLoadError, shouldReloadNow } from './chunkReload';
+
+describe('isChunkLoadError', () => {
+  it('matches Vite/Chrome failed dynamic import messages', () => {
+    expect(isChunkLoadError(new Error('Failed to fetch dynamically imported module: https://x/assets/Foo-abc123.js'))).toBe(true);
+    expect(isChunkLoadError(new Error('error loading dynamically imported module'))).toBe(true);
+  });
+
+  it('matches the Safari/Firefox module-script wording', () => {
+    expect(isChunkLoadError(new Error('Importing a module script failed.'))).toBe(true);
+  });
+
+  it('matches webpack-style ChunkLoadError (by name and by message)', () => {
+    const byName = Object.assign(new Error('boom'), { name: 'ChunkLoadError' });
+    expect(isChunkLoadError(byName)).toBe(true);
+    expect(isChunkLoadError(new Error('Loading chunk 42 failed.'))).toBe(true);
+    expect(isChunkLoadError(new Error('Loading CSS chunk 7 failed.'))).toBe(true);
+  });
+
+  it('accepts a bare string reason', () => {
+    expect(isChunkLoadError('Failed to fetch dynamically imported module')).toBe(true);
+  });
+
+  it('does NOT match ordinary runtime errors', () => {
+    expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
+    expect(isChunkLoadError(new TypeError('x is not a function'))).toBe(false);
+    expect(isChunkLoadError('some GraphQL error')).toBe(false);
+  });
+
+  it('is safe on nullish / weird values', () => {
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError(0)).toBe(false);
+    expect(isChunkLoadError({})).toBe(false);
+  });
+});
+
+describe('shouldReloadNow (loop guard)', () => {
+  function fakeStorage(seed?: string) {
+    const m = new Map<string, string>();
+    if (seed !== undefined) m.set('zif.chunkReloadedAt', seed);
+    return {
+      getItem: (k: string) => m.get(k) ?? null,
+      setItem: (k: string, v: string) => void m.set(k, v),
+      _map: m,
+    };
+  }
+
+  it('allows the first reload and records the timestamp', () => {
+    const s = fakeStorage();
+    expect(shouldReloadNow(1_000_000, s)).toBe(true);
+    expect(s._map.get('zif.chunkReloadedAt')).toBe('1000000');
+  });
+
+  it('blocks a second reload inside the cooldown window', () => {
+    const s = fakeStorage();
+    expect(shouldReloadNow(1_000_000, s)).toBe(true);
+    // 5s later — still inside the 15s cooldown
+    expect(shouldReloadNow(1_005_000, s)).toBe(false);
+  });
+
+  it('allows a reload again once the cooldown has elapsed', () => {
+    const s = fakeStorage('1000000');
+    // 20s later — past the 15s cooldown
+    expect(shouldReloadNow(1_020_000, s)).toBe(true);
+  });
+
+  it('allows the reload when storage throws (blocked)', () => {
+    const blocked = {
+      getItem: () => { throw new Error('storage disabled'); },
+      setItem: () => { throw new Error('storage disabled'); },
+    };
+    expect(shouldReloadNow(1_000_000, blocked)).toBe(true);
+  });
+});

--- a/src/lib/chunkReload.ts
+++ b/src/lib/chunkReload.ts
@@ -1,0 +1,118 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Reload-on-stale-chunk handler (#199).
+//
+// The clobber-free deploy retains OLD hashed bundles, so a tab open across a
+// deploy keeps running the code it loaded. But the moment that tab tries to
+// fetch an asset it does NOT already have in memory — a lazily dynamic-imported
+// chunk, or a re-requested script/stylesheet whose hash changed — the request
+// hits a filename that the new deploy may not serve, 404s, and the interaction
+// silently hangs (a blank panel, a dead click).
+//
+// This installs a global listener that recognises those stale-chunk / failed
+// dynamic-import failures and recovers by reloading the tab once, which pulls
+// the current bundle. A short cooldown (persisted in sessionStorage) prevents a
+// reload loop if the chunk is genuinely, permanently missing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Signatures browsers use for a failed dynamic import / stale chunk fetch. These
+// vary across engines (Chrome/Firefox/Safari) and across Vite/webpack wording,
+// so we match the union. Kept as a single source of truth for the test.
+const CHUNK_ERROR_RE =
+  /(Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed|Loading chunk \S+ failed|Loading CSS chunk|ChunkLoadError)/i;
+
+/**
+ * True when `reason` looks like a stale-chunk / failed dynamic-import error
+ * (as opposed to an ordinary runtime error we must NOT reload for). Accepts a
+ * string, an Error, or an arbitrary thrown value. Never throws.
+ */
+export function isChunkLoadError(reason: unknown): boolean {
+  if (!reason) return false;
+  const r = reason as { name?: unknown; message?: unknown };
+  if (r.name === 'ChunkLoadError') return true;
+  const msg =
+    typeof reason === 'string'
+      ? reason
+      : typeof r.message === 'string'
+        ? r.message
+        : String(reason);
+  return CHUNK_ERROR_RE.test(msg);
+}
+
+// sessionStorage key + cooldown. sessionStorage (not localStorage) so the guard
+// is scoped to THIS tab and clears when the tab closes.
+const RELOAD_KEY = 'zif.chunkReloadedAt';
+const RELOAD_COOLDOWN_MS = 15_000;
+
+type ReadWriteStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+/**
+ * Loop guard: returns true (and records the attempt) only if we have NOT already
+ * reloaded for a chunk error within the cooldown window. If the chunk is
+ * permanently missing, the post-reload failure lands inside the cooldown and we
+ * stop — showing the broken state rather than reload-looping forever.
+ *
+ * Pulled out as a pure function (storage injected) so it is unit-testable in the
+ * node test env without a real Window.
+ */
+export function shouldReloadNow(now: number, storage: ReadWriteStorage): boolean {
+  try {
+    const last = Number(storage.getItem(RELOAD_KEY) ?? '0');
+    if (Number.isFinite(last) && now - last < RELOAD_COOLDOWN_MS) return false;
+    storage.setItem(RELOAD_KEY, String(now));
+    return true;
+  } catch {
+    // Storage blocked (private mode). Allow the reload — a genuine deploy fetch
+    // will succeed after it; the in-memory `armed` guard below still prevents a
+    // duplicate reload within the same page life.
+    return true;
+  }
+}
+
+// In-memory latch so several simultaneous errors (preloadError + unhandled
+// rejection for the same import) only schedule ONE reload.
+let armed = true;
+
+/**
+ * Install the global stale-chunk recovery listener. Idempotent per page life via
+ * the `armed` latch. Call once, before/at app bootstrap.
+ */
+export function installChunkReloadHandler(win: Window & typeof globalThis = window): void {
+  const recover = (reason: unknown): void => {
+    if (!armed) return;
+    if (!isChunkLoadError(reason)) return;
+    let store: ReadWriteStorage | undefined;
+    try {
+      store = win.sessionStorage;
+    } catch {
+      store = undefined;
+    }
+    if (store && !shouldReloadNow(Date.now(), store)) {
+      // Already reloaded recently for a chunk error → the chunk is genuinely
+      // gone. Stop looping; leave the broken state visible.
+      armed = false;
+      return;
+    }
+    armed = false;
+    // Auto-reload (over a prompt): a tab that can't fetch a chunk is already
+    // non-functional, so a silent refresh to the current bundle is the
+    // least-surprising recovery.
+    win.location.reload();
+  };
+
+  // Vite fires this when a dynamically-imported chunk fails to preload/load.
+  // preventDefault() stops Vite's default rethrow so we own the recovery.
+  win.addEventListener('vite:preloadError', (e: Event) => {
+    e.preventDefault();
+    recover((e as unknown as { payload?: unknown }).payload ?? e);
+  });
+
+  // A rejected import() (or any promise rejecting with a chunk error).
+  win.addEventListener('unhandledrejection', (e: PromiseRejectionEvent) => {
+    recover(e.reason);
+  });
+
+  // A <script>/<link> asset that failed to load surfaces as a global error.
+  win.addEventListener('error', (e: ErrorEvent) => {
+    recover(e.error ?? e.message);
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { installChunkReloadHandler } from './lib/chunkReload';
 import { t } from './ui/theme';
+
+// #199: recover a tab left open across a deploy — a stale/404'd chunk fetch
+// (failed dynamic import or re-requested hashed asset) auto-reloads to the
+// current bundle instead of silently hanging. Installed before render so the
+// listener is live for the very first chunk request.
+installChunkReloadHandler();
 
 // Global resets (the only non-inline CSS we need).
 const css = `


### PR DESCRIPTION
## #199 — mid-session deploy hangs open tabs on stale chunk requests

### Problem
The clobber-free deploy retains old hashed bundles, so a tab open across a deploy keeps running. But when it later fetches an asset it doesn't already hold — a lazily dynamic-imported chunk, or a re-requested hashed script/stylesheet — that request can 404 against the new deploy and the interaction silently hangs (dead click, blank panel).

### Fix
New `src/lib/chunkReload.ts`, wired in `main.tsx` before render:
- Listens for `vite:preloadError`, `unhandledrejection`, and asset `error` events.
- `isChunkLoadError()` recognises the stale-chunk / failed-dynamic-import signatures across Chrome/Firefox/Safari and Vite/webpack wording.
- On a match, **auto-reloads once** to pull the current bundle (chosen over a prompt — a tab that can't fetch a chunk is already non-functional; a silent refresh is the least-surprising recovery).
- **Loop guard**: a 15s `sessionStorage`-scoped cooldown + an in-memory latch. If the chunk is genuinely, permanently missing, the post-reload failure lands inside the cooldown and we stop — leaving the broken state visible instead of reload-looping.

### Test
`src/lib/chunkReload.test.ts` — 10 cases covering message/name matching, non-chunk errors, nullish safety, the cooldown window, and the storage-blocked fallback. `npx vitest run` → 10 passed.

### Verification
- `tsc -b` clean
- prod build → live bundle, `wss://…/v1/graphql` present, handler present in bundle

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww1rWnKu1dcfkK57i1UmGu