### PR TITLE
fix(#201): consolidate realized-net formula into lib/income.realizedNet

### DIFF
--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -5,6 +5,8 @@ import { Card, Mono, StatCard } from '../ui/primitives';
 import { t } from '../ui/theme';
 import { k, kc, usd, col } from '../lib/format';
 import { useIsMobile } from '../lib/useIsMobile';
+import { realizedNet } from '../lib/income';
+import type { IncomeCategory } from '../types';
 import { PositionsSection } from './Positions';
 
 // #212-analytics: compact "since you last checked" pulse. Funding + net income
@@ -30,14 +32,14 @@ function usePulse(prevLastCheckedMs: number) {
     ])
       .then(([rows, win]) => {
         if (cancelled) return;
-        let fund = 0, net = 0;
-        const INCOME = new Set(['realized_trade', 'funding', 'fee', 'reward', 'interest']);
-        for (const r of rows) {
-          if (r.category === 'funding') fund += r.amount;
-          if (INCOME.has(r.category)) net += r.amount;
-        }
-        setFunding(fund);
-        setNetIncome(net);
+        // #201: fold the raw ledger rows into per-category sums, then derive the
+        // realized net from the SAME realizedNet helper the live/mock LedgerTotals
+        // mappers use (income cats only; transfer + hack excluded) — no local copy
+        // of the income-category set / net formula.
+        const byCat: Partial<Record<IncomeCategory, number>> = {};
+        for (const r of rows) byCat[r.category] = (byCat[r.category] ?? 0) + r.amount;
+        setFunding(byCat.funding ?? 0);
+        setNetIncome(realizedNet(byCat));
         setExits(win.agg.count);
         setReady(true);
       })

--- a/src/data/apolloSource.ts
+++ b/src/data/apolloSource.ts
@@ -18,6 +18,7 @@ import {
   PNL_DAILY_QUERY,
 } from '../graphql/operations';
 import { EVENT_BUCKET_COLUMN } from '../lib/pnlDaily';
+import { realizedNet } from '../lib/income';
 import type {
   Position, Portfolio, Wallet, OrderLevel, RestingOrder, ActivityEvent, ActivityFilter, ClosedTrade, Account, Exchange, Accuracy, ReconcileStatus, Side,
   ClosedAgg, ClosedGroupAgg, ClosedWindow, PerfDim, Lifecycle, LifecycleMap,
@@ -354,7 +355,9 @@ const mapLedgerTotals = (d: any): LedgerTotals => {
   const hacks = catSum(d, 'hack');
   return {
     tradePnl, funding, fees, rewards, interest, hacks,
-    netPnl: tradePnl + funding + fees + rewards + interest,
+    // #201: single source of truth for "realized net" (income cats only; hack +
+    // transfer excluded). See lib/income.realizedNet.
+    netPnl: realizedNet({ realized_trade: tradePnl, funding, fee: fees, reward: rewards, interest }),
   };
 };
 

--- a/src/data/mockEngine.ts
+++ b/src/data/mockEngine.ts
@@ -9,6 +9,7 @@ import type {
 } from '../types';
 import type { OmniRawEventInsert } from '../lib/omniCsvParser';
 import { pnlAt } from '../lib/pnl';
+import { realizedNet } from '../lib/income';
 import {
   seedPositions, seedLevels, seedOrders, seedWallets, seedClosedTrades, seedActivity,
 } from './mockSeed';
@@ -445,11 +446,11 @@ export class MockEngine {
           if (r.periodType !== 'day') continue;
           if (r.periodStart < sinceMs || r.periodStart > untilMs) continue;
           switch (r.category) {
-            case 'realized_trade': acc.tradePnl += r.amount; acc.netPnl += r.amount; break;
-            case 'funding': acc.funding += r.amount; acc.netPnl += r.amount; break;
-            case 'fee': acc.fees += r.amount; acc.netPnl += r.amount; break;
-            case 'reward': acc.rewards += r.amount; acc.netPnl += r.amount; break;
-            case 'interest': acc.interest += r.amount; acc.netPnl += r.amount; break;
+            case 'realized_trade': acc.tradePnl += r.amount; break;
+            case 'funding': acc.funding += r.amount; break;
+            case 'fee': acc.fees += r.amount; break;
+            case 'reward': acc.rewards += r.amount; break;
+            case 'interest': acc.interest += r.amount; break;
             case 'hack': acc.hacks += r.amount; break; // NOT in netPnl
             // transfer: excluded from both
           }
@@ -457,6 +458,9 @@ export class MockEngine {
         // Seed a demo hack (April 1 of the current year) so the card renders nonzero.
         const hackTs = Date.UTC(new Date().getUTCFullYear(), 3, 1);
         if (hackTs >= sinceMs && hackTs <= untilMs) acc.hacks += -342670.32;
+        // #201: derive netPnl from the SAME realizedNet helper the live path uses
+        // (income cats only; hack excluded) so mock + live can't drift.
+        acc.netPnl = realizedNet({ realized_trade: acc.tradePnl, funding: acc.funding, fee: acc.fees, reward: acc.rewards, interest: acc.interest });
         return acc;
       },
 

--- a/src/lib/income.test.ts
+++ b/src/lib/income.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { realizedNet } from './income';
+
+describe('realizedNet', () => {
+  it('sums the five income components', () => {
+    expect(realizedNet({ realized_trade: 100, funding: 20, fee: -5, reward: 3, interest: 2 })).toBe(120);
+  });
+
+  it('treats missing components as 0', () => {
+    expect(realizedNet({ realized_trade: 100 })).toBe(100);
+    expect(realizedNet({})).toBe(0);
+  });
+
+  it('honours the sign of fees (already-signed, negative cost)', () => {
+    expect(realizedNet({ realized_trade: 0, fee: -50 })).toBe(-50);
+  });
+
+  it('EXCLUDES hack and transfer — they are not income', () => {
+    // Even when present on the input map, hack/transfer must not contribute.
+    expect(realizedNet({ realized_trade: 10, hack: -342670.32, transfer: 999 })).toBe(10);
+  });
+
+  it('matches the live LedgerTotals identity (trade+funding+fee+reward+interest)', () => {
+    const parts = { realized_trade: 700581.53, funding: 12000.4, fee: -8000.1, reward: 250, interest: 90.2 };
+    const expected =
+      parts.realized_trade + parts.funding + parts.fee + parts.reward + parts.interest;
+    expect(realizedNet(parts)).toBeCloseTo(expected, 6);
+  });
+});

--- a/src/lib/income.ts
+++ b/src/lib/income.ts
@@ -17,6 +17,26 @@ export const INCOME_CATS: { c: IncomeCategory; label: string; short: string }[] 
 ];
 export const INCOME_CAT_SET = new Set<IncomeCategory>(INCOME_CATS.map((x) => x.c));
 
+// ─────────────────────────────────────────────────────────────────────────────
+// realizedNet — THE single definition of "realized PnL net" (#201).
+//
+// Realized net = the signed sum of the five INCOME categories only
+// (realized_trade + funding + fee + reward + interest). `transfer` and `hack`
+// are NOT income (per tax_category) and never contribute — a hack surfaces on
+// its own card, a transfer is a plain flow. Every field is already SIGNED (fees
+// arrive as a negative amount), so this is a plain sum, never a negation.
+//
+// This replaces three hand-inlined copies of the same formula (the live
+// LedgerTotals mapper, the mock LedgerTotals reducer, and the Overview
+// net-income fold) so they can never drift apart. Callers pass whatever subset
+// of the five components they hold, keyed by IncomeCategory; missing keys are 0.
+// ─────────────────────────────────────────────────────────────────────────────
+export function realizedNet(byCat: Partial<Record<IncomeCategory, number>>): number {
+  let net = 0;
+  for (const { c } of INCOME_CATS) net += byCat[c] ?? 0;
+  return net;
+}
+
 export const GRAINS: { k: IncomeGrain; label: string }[] = [
   { k: 'day', label: 'Day' },
   { k: 'week', label: 'Week' },


### PR DESCRIPTION
## #201 — triplicated realized-PnL formula

The "realized PnL net" formula — the signed sum of the five **income** categories only (`realized_trade + funding + fee + reward + interest`; `hack` + `transfer` excluded) — was hand-inlined in three places that could silently drift:

1. `apolloSource.mapLedgerTotals` → `tradePnl + funding + fees + rewards + interest`
2. `mockEngine.fetchLedgerTotals` → per-case `acc.netPnl += ...` accumulation
3. `Overview` income fold → a locally-redefined income-category `Set` + loop

### Fix
Add one `realizedNet(byCat)` helper in `lib/income.ts` (built on the existing `INCOME_CATS` source of truth) and route all three through it:
- **apolloSource** + **mockEngine** map their named `LedgerTotals` fields onto the `IncomeCategory` keys and call `realizedNet` (mockEngine now derives `netPnl` once after the reduce instead of accumulating inline).
- **Overview** folds raw ledger rows into per-category sums and reads both funding and the net from that map — deleting its private income-category `Set`.

Behavior is **identical** (all three were the same signed sum) — this just removes the duplication so they can't diverge.

### Test
`src/lib/income.test.ts` — covers the sum, missing-component defaults, fee sign, the hack/transfer exclusion, and the live LedgerTotals identity. `vitest run` → 64 passed (5 new).

### Verification
- `tsc -b` clean
- prod build → live bundle, `wss://…/v1/graphql` present

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww1rWnKu1dcfkK57i1UmGu