### PR TITLE
feat(#202): HL reduce-only TP/SL set-and-rest (dark behind VITE_ENABLE_HL_ORDERS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.11.8",
+        "@nktkas/hyperliquid": "^0.32.2",
         "@tanstack/react-virtual": "^3.10.8",
         "graphql": "^16.9.0",
         "graphql-ws": "^5.16.0",
         "lightweight-charts": "^4.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "viem": "^2.55.5",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -25,6 +27,12 @@
         "vite": "^5.4.8",
         "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@apollo/client": {
       "version": "3.14.1",
@@ -907,6 +915,80 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nktkas/hyperliquid": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@nktkas/hyperliquid/-/hyperliquid-0.32.2.tgz",
+      "integrity": "sha512-0Wh/keNAgnfdA/cLmdJDDzTZq/CSoT3lL/eY+MzF9R5U10d5J6nin/sEaH5HA+9K8CIag36ZtZ9dCxDvYEb0nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nktkas/rews": "^2",
+        "@noble/hashes": "^2",
+        "valibot": "1.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@nktkas/rews": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nktkas/rews/-/rews-2.1.2.tgz",
+      "integrity": "sha512-IuOhyKc9UYwJr2UD3f0m7w0NZepI3kkR+94jQi5sCS0lQFujsxRpjZlourZVH0y4U4ZfkV3JtJcqJl3zG0rZfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
@@ -1531,6 +1613,66 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1829,6 +1971,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2032,6 +2195,12 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2134,6 +2303,21 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/js-tokens": {
@@ -2541,6 +2725,48 @@
         "tslib": "^2.3.0"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.31",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.31.tgz",
+      "integrity": "sha512-WqtI37YEJCV6wkLw877FPrwWHwXEFrVZLecqBqQQjUmFhATjd+upfaKpWHXrhKaRUPMU6LH8T1lydHBda5ww5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2878,7 +3104,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -2926,6 +3152,62 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.55.5",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.5.tgz",
+      "integrity": "sha512-2GaTBslLhbP1xUbFoSkFbzKye5W76ixPlaqPg96HFyc40R76t95dqITYoXXr/xP9bhmDLYKxLODTLoiWWjpViQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.31",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/vite": {
@@ -3656,6 +3938,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -6,16 +6,19 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apollo/client": "^3.11.8",
+    "@nktkas/hyperliquid": "^0.32.2",
     "@tanstack/react-virtual": "^3.10.8",
     "graphql": "^16.9.0",
     "graphql-ws": "^5.16.0",
     "lightweight-charts": "^4.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "viem": "^2.55.5",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/src/components/ExitPlanner.tsx
+++ b/src/components/ExitPlanner.tsx
@@ -6,6 +6,7 @@ import { pnlAt, ladderSummary, hasDisplayableLiq } from '../lib/pnl';
 import { px, kc, k, col, pricePrecision } from '../lib/format';
 import { t } from '../ui/theme';
 import { useIsMobile } from '../lib/useIsMobile';
+import { HlOrderActions } from './HlOrderActions';
 import type { Position, OrderLevel, RestingOrder } from '../types';
 
 const LABELW = 148;
@@ -183,6 +184,9 @@ export function ExitPlanner({ p }: { p: Position }) {
             <span style={{ color: t.mut }}>If all TPs fill <b style={{ color: t.green }}>{k(summary.total)}</b> · {summary.cov}% covered</span>
             <span style={{ color: t.mut }}>Stops cap at <b style={{ color: t.red }}>{k(slSummary.total)}</b> · {slSummary.cov}% covered</span>
           </div>
+          {/* #202 reduce-only on-exchange TP/SL (dark behind VITE_ENABLE_HL_ORDERS;
+              renders nothing unless the flag is on AND this is a Hyperliquid PERP) */}
+          <HlOrderActions p={p} />
         </div>
       )}
     </div>

--- a/src/components/HlOrderActions.tsx
+++ b/src/components/HlOrderActions.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react';
+import type { Position } from '../types';
+import { useStore } from '../store/store';
+import { t } from '../ui/theme';
+import { px } from '../lib/format';
+import {
+  hlOrdersEnabled,
+  closingSide,
+  formatPx,
+  formatSize,
+  placeTrigger,
+  cancel as cancelOrder,
+  type Tpsl,
+  type PlaceResult,
+} from '../data/hlOrders';
+import { resolveIndex } from '../data/hlMeta';
+import { connectWallet, hasWallet } from '../data/hlWallet';
+import { guardPosition, findAccount, checkMatch, isOrderablePosition } from '../data/hlGuard';
+
+// #202 — Reduce-only TP/SL "set-and-rest" quick actions. The user's OWN browser
+// wallet signs the HL L1 order action in-browser; nothing key-shaped is stored;
+// reduceOnly:true is the native guard. The WHOLE surface is behind
+// VITE_ENABLE_HL_ORDERS (default OFF) and only renders for Hyperliquid PERPs.
+
+type Phase = 'idle' | 'confirm' | 'working' | 'placed' | 'error';
+
+interface PlacedOrder {
+  oid: number;
+  assetIndex: number;
+  tpsl: Tpsl;
+  triggerPx: string;
+  size: string;
+}
+
+// Default percent offset presets (feel-matched to the ExitPlanner ±5% ladder adds).
+const OFFSET_PRESETS = [2, 5, 10];
+
+export function HlOrderActions({ p }: { p: Position }) {
+  // Two hard gates: the dark-launch flag AND venue/type. Either off → render nothing.
+  if (!hlOrdersEnabled() || !isOrderablePosition(p)) return null;
+  return <HlOrderActionsInner p={p} />;
+}
+
+function HlOrderActionsInner({ p }: { p: Position }) {
+  const wallets = useStore((s) => s.wallets);
+  const account = findAccount(wallets, p.exchangeAccountId);
+
+  const [pct, setPct] = useState(5);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [pending, setPending] = useState<{ tpsl: Tpsl; triggerPx: string; size: string } | null>(null);
+  const [placed, setPlaced] = useState<PlacedOrder[]>([]);
+  const [msg, setMsg] = useState<string>('');
+
+  // Static pre-check that does NOT need a connected wallet: is this account even
+  // orderable (has an owner address, not a subaccount)? Disables the buttons with
+  // the reason when not.
+  const preCheck = checkMatch(account, account?.walletAddress ?? null);
+  const staticBlocked =
+    preCheck.code === 'no-account' ||
+    preCheck.code === 'no-owner-address' ||
+    preCheck.code === 'subaccount-unsupported';
+
+  // Trigger price for a reduce-only exit of this position, given a % offset off mark.
+  //   LONG:  SL below mark, TP above mark
+  //   SHORT: SL above mark, TP below mark
+  function triggerFor(tpsl: Tpsl): number {
+    const f = pct / 100;
+    const above = p.mark * (1 + f);
+    const below = p.mark * (1 - f);
+    if (p.side === 'LONG') return tpsl === 'tp' ? above : below;
+    return tpsl === 'tp' ? below : above;
+  }
+
+  function startConfirm(tpsl: Tpsl) {
+    try {
+      const triggerPx = formatPx(triggerFor(tpsl));
+      const size = formatSize(p.units);
+      setPending({ tpsl, triggerPx, size });
+      setMsg('');
+      setPhase('confirm');
+    } catch (e: any) {
+      setMsg(e?.message ?? 'Could not build order.');
+      setPhase('error');
+    }
+  }
+
+  async function doPlace() {
+    if (!pending) return;
+    setPhase('working');
+    setMsg('Connecting wallet…');
+    try {
+      const conn = await connectWallet();
+      // Runtime match-guard: connected EOA MUST equal the account owner.
+      const guard = guardPosition(wallets, p, conn.address);
+      if (!guard.ok) throw new Error(guard.reason);
+
+      setMsg('Resolving market…');
+      const assetIndex = await resolveIndex(p.asset);
+      if (assetIndex === null) throw new Error(`Unknown HL market for ${p.asset}.`);
+
+      setMsg('Awaiting signature…');
+      const res: PlaceResult = await placeTrigger(conn.exchange, {
+        assetIndex,
+        isBuy: closingSide(p.side),
+        size: pending.size,
+        triggerPx: pending.triggerPx,
+        tpsl: pending.tpsl,
+      });
+
+      if (res.oid !== null) {
+        setPlaced((prev) => [
+          ...prev,
+          { oid: res.oid!, assetIndex, tpsl: pending.tpsl, triggerPx: pending.triggerPx, size: pending.size },
+        ]);
+      }
+      setMsg(res.filled ? 'Order filled immediately.' : `Order resting (oid ${res.oid ?? '—'}).`);
+      setPhase('placed');
+      setPending(null);
+    } catch (e: any) {
+      setMsg(e?.message ?? 'Order failed.');
+      setPhase('error');
+    }
+  }
+
+  async function doCancel(o: PlacedOrder) {
+    setPhase('working');
+    setMsg('Awaiting signature to cancel…');
+    try {
+      const conn = await connectWallet();
+      const guard = guardPosition(wallets, p, conn.address);
+      if (!guard.ok) throw new Error(guard.reason);
+      await cancelOrder(conn.exchange, { assetIndex: o.assetIndex, oid: o.oid });
+      setPlaced((prev) => prev.filter((x) => x.oid !== o.oid));
+      setMsg(`Cancelled oid ${o.oid}.`);
+      setPhase('placed');
+    } catch (e: any) {
+      setMsg(e?.message ?? 'Cancel failed.');
+      setPhase('error');
+    }
+  }
+
+  return (
+    <div style={{ marginTop: 10, paddingTop: 10, borderTop: `1px solid ${t.border2}` }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: t.acc, letterSpacing: '.04em' }}>
+          ON-EXCHANGE EXIT
+        </span>
+        <span style={{ fontSize: 11, color: t.mut2 }}>reduce-only · you sign in your wallet</span>
+      </div>
+
+      {staticBlocked ? (
+        <div style={{ marginTop: 8, fontSize: 12, color: t.amber }}>{preCheck.reason}</div>
+      ) : (
+        <>
+          {/* percent-offset preset control (feel-matched to the ladder ±% adds) */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 9, flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 12, color: t.mut }}>Offset</span>
+            {OFFSET_PRESETS.map((v) => (
+              <button
+                key={v}
+                onClick={() => setPct(v)}
+                style={chip(pct === v)}
+              >
+                {v}%
+              </button>
+            ))}
+            <span style={{ fontSize: 12, color: t.mut2 }}>from mark {px(p.mark)}</span>
+          </div>
+
+          <div style={{ display: 'flex', gap: 7, marginTop: 9, flexWrap: 'wrap' }}>
+            <button onClick={() => startConfirm('tp')} disabled={phase === 'working'} style={btn(t.green, '#1f4a3a')}>
+              Set TP {px(triggerFor('tp'))}
+            </button>
+            <button onClick={() => startConfirm('sl')} disabled={phase === 'working'} style={btn(t.red, '#4a2a2c')}>
+              Set SL {px(triggerFor('sl'))}
+            </button>
+          </div>
+
+          {/* Confirm-before-sign */}
+          {phase === 'confirm' && pending && (
+            <div style={{ marginTop: 10, padding: 10, background: t.panel, border: `1px solid ${t.border}`, borderRadius: 10 }}>
+              <div style={{ fontSize: 12, color: t.text, lineHeight: 1.5 }}>
+                Place a <b style={{ color: pending.tpsl === 'tp' ? t.green : t.red }}>{pending.tpsl.toUpperCase()}</b>{' '}
+                reduce-only market trigger to {closingSide(p.side) ? 'BUY' : 'SELL'}{' '}
+                <b>{pending.size}</b> {p.asset} at trigger <b>{'$' + pending.triggerPx}</b>.
+              </div>
+              <div style={{ fontSize: 11, color: t.mut2, marginTop: 4 }}>
+                Signed by your connected wallet. reduceOnly — it can only shrink this position.
+              </div>
+              <div style={{ display: 'flex', gap: 7, marginTop: 9 }}>
+                <button onClick={doPlace} style={btn(t.acc, '#2b3556')}>Confirm &amp; sign</button>
+                <button onClick={() => { setPhase('idle'); setPending(null); }} style={btn(t.mut, t.border)}>Cancel</button>
+              </div>
+            </div>
+          )}
+
+          {/* status line */}
+          {msg && (
+            <div style={{ marginTop: 8, fontSize: 12, color: phase === 'error' ? t.red : t.mut }}>
+              {msg}
+              {!hasWallet() && phase === 'error' && ' '}
+            </div>
+          )}
+
+          {/* session-placed orders with cancel */}
+          {placed.length > 0 && (
+            <div style={{ marginTop: 9 }}>
+              {placed.map((o) => (
+                <div key={o.oid} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: t.mut, marginTop: 4 }}>
+                  <span style={{ color: o.tpsl === 'tp' ? t.green : t.red, fontWeight: 600 }}>{o.tpsl.toUpperCase()}</span>
+                  <span>{o.size} {p.asset} @ ${o.triggerPx}</span>
+                  <span style={{ color: t.mut2 }}>oid {o.oid}</span>
+                  <button onClick={() => doCancel(o)} disabled={phase === 'working'} style={{ ...btn(t.mut, t.border), padding: '3px 8px' }}>
+                    Cancel
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+const btn = (color: string, bd: string): React.CSSProperties => ({
+  fontFamily: t.sans, fontSize: 12, fontWeight: 600, cursor: 'pointer', background: 'none',
+  color, border: `1px solid ${bd}`, borderRadius: 8, padding: '6px 11px',
+});
+
+const chip = (active: boolean): React.CSSProperties => ({
+  fontFamily: t.mono, fontSize: 11, fontWeight: 600, cursor: 'pointer',
+  background: active ? t.acc + '22' : 'none', color: active ? t.acc : t.mut,
+  border: `1px solid ${active ? t.acc : t.border}`, borderRadius: 7, padding: '3px 9px',
+});

--- a/src/data/hlGuard.test.ts
+++ b/src/data/hlGuard.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { findAccount, isSubaccount, checkMatch, guardPosition, isOrderablePosition } from './hlGuard';
+import type { Account, Position, Wallet } from '../types';
+
+const OWNER = '0xAbC0000000000000000000000000000000000001';
+
+const acct = (over: Partial<Account>): Account => ({
+  id: 'acc1', walletId: 'w1', name: 'main', exch: 'Hyperliquid', type: 'main',
+  value: 0, pnl: 0, accuracy: 'synced', dataComplete: true, gapAmount: 0,
+  reconcileStatus: 'reconciled', needsApi: false, apiProvided: true, apiSkipped: false,
+  hidden: false, tags: [], walletAddress: OWNER, accountIdentifier: OWNER,
+  unrealized: 0, netDeposits: 0, netFlow: 0, ...over,
+});
+
+const wallet = (accounts: Account[]): Wallet => ({
+  id: 'w1', address: OWNER, label: 'Main', status: 'ready', accounts,
+});
+
+const pos = (over: Partial<Position>): Position => ({
+  id: 'p1', exchangeAccountId: 'acc1', asset: 'HYPE', exch: 'Hyperliquid', wallet: 'main',
+  walletLabel: '', side: 'LONG', units: 10, entry: 40, mark: 42, liq: 20, lev: 3,
+  type: 'PERP', unreal: 20, realized: 0, ...over,
+});
+
+describe('findAccount', () => {
+  it('finds an account by exchange_account_id across wallets', () => {
+    const wallets = [wallet([acct({ id: 'acc1' }), acct({ id: 'acc2' })])];
+    expect(findAccount(wallets, 'acc2')?.id).toBe('acc2');
+    expect(findAccount(wallets, 'nope')).toBeNull();
+    expect(findAccount(wallets, undefined)).toBeNull();
+  });
+});
+
+describe('isSubaccount', () => {
+  it('is false for a main account (identifier == owner)', () => {
+    expect(isSubaccount(acct({}))).toBe(false);
+  });
+  it('is true when typed sub', () => {
+    expect(isSubaccount(acct({ type: 'sub' }))).toBe(true);
+  });
+  it('is true when account_identifier differs from wallet_address', () => {
+    expect(isSubaccount(acct({ accountIdentifier: '0xDEAD000000000000000000000000000000000009' }))).toBe(true);
+  });
+});
+
+describe('checkMatch', () => {
+  it('passes when connected == owner (case-insensitive)', () => {
+    const r = checkMatch(acct({}), OWNER.toLowerCase());
+    expect(r.ok).toBe(true);
+    expect(r.code).toBe('ok');
+  });
+  it('fails with no-account when account missing', () => {
+    expect(checkMatch(null, OWNER)).toMatchObject({ ok: false, code: 'no-account' });
+  });
+  it('fails with no-owner-address when walletAddress empty', () => {
+    expect(checkMatch(acct({ walletAddress: '', accountIdentifier: '' }), OWNER)).toMatchObject({
+      ok: false, code: 'no-owner-address',
+    });
+  });
+  it('refuses a subaccount', () => {
+    expect(checkMatch(acct({ type: 'sub' }), OWNER)).toMatchObject({ ok: false, code: 'subaccount-unsupported' });
+  });
+  it('fails not-connected when address empty', () => {
+    expect(checkMatch(acct({}), '')).toMatchObject({ ok: false, code: 'not-connected' });
+    expect(checkMatch(acct({}), null)).toMatchObject({ ok: false, code: 'not-connected' });
+  });
+  it('fails address-mismatch when connected != owner', () => {
+    expect(checkMatch(acct({}), '0x9999000000000000000000000000000000000099')).toMatchObject({
+      ok: false, code: 'address-mismatch',
+    });
+  });
+});
+
+describe('guardPosition', () => {
+  it('resolves the account from wallets then guards', () => {
+    const wallets = [wallet([acct({ id: 'acc1' })])];
+    expect(guardPosition(wallets, pos({}), OWNER).ok).toBe(true);
+    expect(guardPosition(wallets, pos({ exchangeAccountId: 'ghost' }), OWNER)).toMatchObject({
+      ok: false, code: 'no-account',
+    });
+  });
+});
+
+describe('isOrderablePosition', () => {
+  it('true only for Hyperliquid PERP', () => {
+    expect(isOrderablePosition(pos({}))).toBe(true);
+    expect(isOrderablePosition(pos({ type: 'spot' }))).toBe(false);
+    expect(isOrderablePosition(pos({ exch: 'Lighter' }))).toBe(false);
+  });
+});

--- a/src/data/hlGuard.ts
+++ b/src/data/hlGuard.ts
@@ -1,0 +1,115 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// #202 — Match-guard: the client-side safety check that the CONNECTED browser
+// wallet is the OWNER of the account whose position we're about to place a
+// reduce-only order on.
+//
+// Why: an order is signed by whatever EOA is active in the extension. Before we
+// let that signature go out we assert the active address equals the account's
+// OWNED parent EOA (`walletAddress`). A mismatch (user connected the wrong
+// wallet) is refused BEFORE signing — the reduce-only flag is the on-exchange
+// backstop, this guard is the intent backstop.
+//
+// MVP scope: only MAIN accounts where the signing EOA == the owner. If the
+// account looks like a SUBACCOUNT — `account_identifier` is set and differs from
+// `wallet_address`, or the account is typed 'sub' — signing is disabled with a
+// "subaccount signing not yet supported" note (parent-EOA-signs-for-subaccount is
+// a follow-up that needs an operator decision on the signing model).
+//
+// Pure functions only — no store, no network — so every branch is unit-tested.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { Account, Position, Wallet } from '../types';
+
+const norm = (s: string | undefined | null): string => (s ?? '').trim().toLowerCase();
+
+export type GuardCode =
+  | 'ok'
+  | 'no-account'
+  | 'no-owner-address'
+  | 'subaccount-unsupported'
+  | 'not-connected'
+  | 'address-mismatch';
+
+export interface GuardResult {
+  ok: boolean;
+  code: GuardCode;
+  /** Human-readable reason for the UI. */
+  reason: string;
+}
+
+const OK: GuardResult = { ok: true, code: 'ok', reason: '' };
+
+/** Flatten the wallets store into a flat account list and find one by id. */
+export function findAccount(wallets: Wallet[], exchangeAccountId: string | undefined): Account | null {
+  if (!exchangeAccountId) return null;
+  for (const w of wallets) {
+    for (const a of w.accounts) {
+      if (a.id === exchangeAccountId) return a;
+    }
+  }
+  return null;
+}
+
+/**
+ * True when the account is (or looks like) a subaccount whose signing EOA is not
+ * the account's own on-chain address — out of MVP scope.
+ * Signals: typed 'sub', OR account_identifier present and != wallet_address.
+ */
+export function isSubaccount(account: Account): boolean {
+  if (account.type === 'sub') return true;
+  const ident = norm(account.accountIdentifier);
+  const owner = norm(account.walletAddress);
+  return ident !== '' && owner !== '' && ident !== owner;
+}
+
+/**
+ * The core guard. Given the resolved Account and the connected wallet address,
+ * decide whether an order may be signed for this account.
+ */
+export function checkMatch(account: Account | null, connectedAddress: string | null | undefined): GuardResult {
+  if (!account) {
+    return { ok: false, code: 'no-account', reason: 'Could not resolve the account for this position.' };
+  }
+  const owner = norm(account.walletAddress);
+  if (!owner) {
+    return { ok: false, code: 'no-owner-address', reason: 'This account has no owning wallet address on file.' };
+  }
+  if (isSubaccount(account)) {
+    return {
+      ok: false,
+      code: 'subaccount-unsupported',
+      reason: 'Subaccount signing not yet supported — only main accounts (signing EOA = owner) can place orders in this MVP.',
+    };
+  }
+  const connected = norm(connectedAddress);
+  if (!connected) {
+    return { ok: false, code: 'not-connected', reason: 'Connect your wallet to place an order.' };
+  }
+  if (connected !== owner) {
+    return {
+      ok: false,
+      code: 'address-mismatch',
+      reason: `Connected wallet ${connected.slice(0, 6)}…${connected.slice(-4)} is not the owner of this account (${owner.slice(0, 6)}…${owner.slice(-4)}).`,
+    };
+  }
+  return OK;
+}
+
+/** Convenience: resolve the account from the store wallets and run the guard. */
+export function guardPosition(
+  wallets: Wallet[],
+  position: Position,
+  connectedAddress: string | null | undefined,
+): GuardResult {
+  const account = findAccount(wallets, position.exchangeAccountId);
+  return checkMatch(account, connectedAddress);
+}
+
+/**
+ * Whether the HL order surface should even render for a position: the venue must
+ * be Hyperliquid and the position a PERP. (The flag gate is checked separately by
+ * the caller so this stays a pure predicate.)
+ */
+export function isOrderablePosition(position: Position): boolean {
+  return position.exch === 'Hyperliquid' && position.type === 'PERP';
+}

--- a/src/data/hlMeta.test.ts
+++ b/src/data/hlMeta.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildIndexMap, symbolToIndex, loadMeta, __resetMetaCache } from './hlMeta';
+
+const META = {
+  universe: [
+    { name: 'BTC' },
+    { name: 'ETH' },
+    { name: 'ATOM' },
+    { name: 'MATIC' },
+    { name: 'DYDX' },
+    { name: 'SOL' },
+    { name: 'HYPE' }, // index 6 in this fixture
+  ],
+};
+
+describe('buildIndexMap', () => {
+  it('maps symbol → array position', () => {
+    const m = buildIndexMap(META);
+    expect(m.get('BTC')).toBe(0);
+    expect(m.get('ETH')).toBe(1);
+    expect(m.get('SOL')).toBe(5);
+    expect(m.get('HYPE')).toBe(6);
+  });
+  it('tolerates a missing/empty universe', () => {
+    expect(buildIndexMap({ universe: [] }).size).toBe(0);
+    expect(buildIndexMap({} as any).size).toBe(0);
+  });
+});
+
+describe('symbolToIndex (after load)', () => {
+  beforeEach(() => __resetMetaCache());
+
+  it('returns null before meta is loaded', () => {
+    expect(symbolToIndex('BTC')).toBeNull();
+  });
+
+  it('resolves case-insensitively and trims -PERP after load', async () => {
+    const fakeFetch = (async () =>
+      ({ ok: true, json: async () => META }) as any) as typeof fetch;
+    await loadMeta(fakeFetch);
+    expect(symbolToIndex('btc')).toBe(0);
+    expect(symbolToIndex('HYPE')).toBe(6);
+    expect(symbolToIndex('SOL-PERP')).toBe(5);
+    expect(symbolToIndex('NOPE')).toBeNull();
+  });
+
+  it('shares one in-flight request and caches', async () => {
+    let calls = 0;
+    const fakeFetch = (async () => {
+      calls++;
+      return { ok: true, json: async () => META } as any;
+    }) as typeof fetch;
+    await Promise.all([loadMeta(fakeFetch), loadMeta(fakeFetch)]);
+    await loadMeta(fakeFetch);
+    expect(calls).toBe(1);
+  });
+
+  it('does not cache a failed fetch (allows retry)', async () => {
+    let calls = 0;
+    const failing = (async () => {
+      calls++;
+      return { ok: false, status: 500, json: async () => ({}) } as any;
+    }) as typeof fetch;
+    await expect(loadMeta(failing)).rejects.toThrow();
+    await expect(loadMeta(failing)).rejects.toThrow();
+    expect(calls).toBe(2);
+  });
+});

--- a/src/data/hlMeta.ts
+++ b/src/data/hlMeta.ts
@@ -1,0 +1,93 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// #202 — Hyperliquid perp `meta` universe → asset-index resolver.
+//
+// The asset index required by an HL L1 order action (`a`) is NOT in our data
+// model (a Position only carries the coin SYMBOL). It is the position of the coin
+// in the `universe[]` array returned by `POST /info {"type":"meta"}` — BTC=0,
+// ETH=1, SOL=5, HYPE=159, … The mapping is stable per coin, so we fetch it once
+// and cache it for the tab's lifetime.
+//
+// This module is pure data-fetch + cache; it does NOT sign or place anything.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HL_INFO_URL = 'https://api.hyperliquid.xyz/info';
+
+/** One entry of the perp `meta.universe` array. Only `name` is load-bearing here. */
+interface UniverseEntry {
+  name: string;
+  [k: string]: unknown;
+}
+interface MetaResponse {
+  universe: UniverseEntry[];
+}
+
+// symbol (UPPER) → index. Empty until the first successful load.
+let cache: Map<string, number> | null = null;
+let inflight: Promise<Map<string, number>> | null = null;
+
+/** Build the symbol→index map from a raw `meta` response. Exported for tests. */
+export function buildIndexMap(meta: MetaResponse): Map<string, number> {
+  const m = new Map<string, number>();
+  const universe = Array.isArray(meta?.universe) ? meta.universe : [];
+  universe.forEach((entry, i) => {
+    const name = (entry?.name ?? '').toString().trim().toUpperCase();
+    if (name) m.set(name, i);
+  });
+  return m;
+}
+
+/**
+ * Fetch + cache the perp universe. Concurrent callers share one in-flight
+ * request. A failed fetch is NOT cached (so a later call can retry).
+ */
+export async function loadMeta(
+  fetchImpl: typeof fetch = fetch,
+): Promise<Map<string, number>> {
+  if (cache) return cache;
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const res = await fetchImpl(HL_INFO_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'meta' }),
+      });
+      if (!res.ok) throw new Error(`meta fetch failed (${res.status})`);
+      const meta = (await res.json()) as MetaResponse;
+      cache = buildIndexMap(meta);
+      return cache;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+/**
+ * Resolve a coin symbol to its HL asset index using the loaded cache.
+ * Returns `null` when the meta hasn't been loaded yet or the symbol is unknown.
+ * Case-insensitive; trims a `-PERP` suffix if present (our display symbol is the
+ * bare coin, but be defensive).
+ */
+export function symbolToIndex(sym: string): number | null {
+  if (!cache) return null;
+  const key = (sym ?? '').trim().toUpperCase().replace(/-PERP$/, '');
+  if (!key) return null;
+  const idx = cache.get(key);
+  return idx === undefined ? null : idx;
+}
+
+/** Convenience: ensure meta is loaded, then resolve. Returns null if unknown. */
+export async function resolveIndex(
+  sym: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number | null> {
+  await loadMeta(fetchImpl);
+  return symbolToIndex(sym);
+}
+
+/** Test-only: reset the module cache between cases. */
+export function __resetMetaCache(): void {
+  cache = null;
+  inflight = null;
+}

--- a/src/data/hlOrders.test.ts
+++ b/src/data/hlOrders.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildTriggerOrderParams,
+  buildCancelParams,
+  closingSide,
+  parseOrderResult,
+  formatPx,
+  formatSize,
+} from './hlOrders';
+
+describe('closingSide', () => {
+  it('closes a LONG by selling (isBuy=false)', () => {
+    expect(closingSide('LONG')).toBe(false);
+  });
+  it('closes a SHORT by buying (isBuy=true)', () => {
+    expect(closingSide('SHORT')).toBe(true);
+  });
+});
+
+describe('buildTriggerOrderParams', () => {
+  it('builds a reduce-only market SL trigger for a LONG (sell)', () => {
+    const params = buildTriggerOrderParams({
+      assetIndex: 159, // HYPE
+      isBuy: closingSide('LONG'),
+      size: '12.5',
+      triggerPx: '38.20',
+      tpsl: 'sl',
+    });
+    expect(params).toEqual({
+      orders: [
+        {
+          a: 159,
+          b: false,
+          p: '0',
+          s: '12.5',
+          r: true,
+          t: { trigger: { isMarket: true, triggerPx: '38.20', tpsl: 'sl' } },
+        },
+      ],
+      grouping: 'na',
+    });
+  });
+
+  it('builds a reduce-only market TP trigger for a SHORT (buy)', () => {
+    const params = buildTriggerOrderParams({
+      assetIndex: 0, // BTC
+      isBuy: closingSide('SHORT'),
+      size: '0.01',
+      triggerPx: '55000',
+      tpsl: 'tp',
+    });
+    expect(params.orders[0].b).toBe(true);
+    expect(params.orders[0].r).toBe(true); // always reduce-only
+    expect(params.orders[0].p).toBe('0'); // market trigger price
+    expect(params.orders[0].t.trigger.isMarket).toBe(true);
+    expect(params.orders[0].t.trigger.tpsl).toBe('tp');
+    expect(params.grouping).toBe('na');
+  });
+
+  it('always sets reduceOnly true (the native safety guard)', () => {
+    const p = buildTriggerOrderParams({ assetIndex: 5, isBuy: true, size: '1', triggerPx: '100', tpsl: 'tp' });
+    expect(p.orders[0].r).toBe(true);
+  });
+
+  it('rejects a non-integer / negative asset index', () => {
+    expect(() => buildTriggerOrderParams({ assetIndex: -1, isBuy: true, size: '1', triggerPx: '1', tpsl: 'tp' })).toThrow();
+    expect(() => buildTriggerOrderParams({ assetIndex: 1.5, isBuy: true, size: '1', triggerPx: '1', tpsl: 'tp' })).toThrow();
+  });
+});
+
+describe('buildCancelParams', () => {
+  it('builds a cancel action for one oid', () => {
+    expect(buildCancelParams({ assetIndex: 1, oid: 987654321 })).toEqual({
+      cancels: [{ a: 1, o: 987654321 }],
+    });
+  });
+  it('rejects invalid asset index or oid', () => {
+    expect(() => buildCancelParams({ assetIndex: -1, oid: 1 })).toThrow();
+    expect(() => buildCancelParams({ assetIndex: 1, oid: -5 })).toThrow();
+  });
+});
+
+describe('parseOrderResult', () => {
+  it('extracts a resting oid', () => {
+    const resp = { status: 'ok', response: { data: { statuses: [{ resting: { oid: 42 } }] } } };
+    expect(parseOrderResult(resp)).toMatchObject({ oid: 42, resting: true, filled: false });
+  });
+  it('extracts a filled oid', () => {
+    const resp = { status: 'ok', response: { data: { statuses: [{ filled: { oid: 7, totalSz: '1' } }] } } };
+    expect(parseOrderResult(resp)).toMatchObject({ oid: 7, resting: false, filled: true });
+  });
+  it('throws on a per-order error string', () => {
+    const resp = { status: 'ok', response: { data: { statuses: [{ error: 'Order would increase position' }] } } };
+    expect(() => parseOrderResult(resp)).toThrow(/increase position/);
+  });
+  it('returns null oid when the shape is unexpected', () => {
+    expect(parseOrderResult({})).toMatchObject({ oid: null, resting: false, filled: false });
+  });
+});
+
+describe('formatPx', () => {
+  it('caps at 5 significant figures for sub-100k prices', () => {
+    expect(formatPx(38.20134)).toBe('38.201');
+    expect(formatPx(0.0234567)).toBe('0.023457');
+  });
+  it('rounds large / integer prices to integers', () => {
+    expect(formatPx(55000)).toBe('55000');
+    expect(formatPx(123456.7)).toBe('123457');
+  });
+  it('rejects non-positive prices', () => {
+    expect(() => formatPx(0)).toThrow();
+    expect(() => formatPx(-5)).toThrow();
+  });
+});
+
+describe('formatSize', () => {
+  it('uses the magnitude and trims trailing zeros', () => {
+    expect(formatSize(12.5)).toBe('12.5');
+    expect(formatSize(-3)).toBe('3');
+  });
+  it('rejects zero', () => {
+    expect(() => formatSize(0)).toThrow();
+  });
+});

--- a/src/data/hlOrders.ts
+++ b/src/data/hlOrders.ts
@@ -1,0 +1,191 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// #202 — Hyperliquid reduce-only TP/SL "set-and-rest" order client.
+//
+// The user's OWN browser EOA signs a Hyperliquid L1 order action in-browser (via
+// the @nktkas/hyperliquid ExchangeClient, which does the msgpack/keccak/EIP-712
+// phantom-agent signing on chainId 1337). NOTHING key-shaped is ever stored.
+//
+// SAFETY MODEL:
+//  - Every order placed here is `r:true` (reduceOnly) — it can only ever shrink an
+//    existing position, never open or flip one. This is the native on-exchange
+//    guard: even a bug can't create new exposure.
+//  - `isMarket:true` trigger + `p:"0"` = a market-execute trigger (a real stop /
+//    take-profit that rests on the book until its trigger price is crossed).
+//  - The whole surface is gated behind VITE_ENABLE_HL_ORDERS (default OFF) so it
+//    is invisible/inert in prod until an operator flips it on.
+//
+// The pure `buildTriggerOrderParams` / `buildCancelParams` builders produce the
+// exact action shapes the SDK methods consume, WITHOUT any network or signing, so
+// they can be unit-tested deterministically. `placeTrigger` / `cancel` wrap the
+// live SDK call and are exercised only against a real wallet (operator-gated).
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { ExchangeClient } from '@nktkas/hyperliquid';
+
+/** True iff the dark-launch flag is explicitly enabled. Default OFF. */
+export function hlOrdersEnabled(): boolean {
+  return import.meta.env.VITE_ENABLE_HL_ORDERS === 'true';
+}
+
+export type Tpsl = 'tp' | 'sl';
+
+export interface PlaceTriggerArgs {
+  /** HL asset index (position in the `meta.universe` array). */
+  assetIndex: number;
+  /**
+   * Order side: `true` = buy, `false` = sell. To CLOSE a LONG you SELL (false);
+   * to close a SHORT you BUY (true). See `closingSide()`.
+   */
+  isBuy: boolean;
+  /** Order size in base-coin units, as a string (exchange precision). */
+  size: string;
+  /** Trigger price as a string. */
+  triggerPx: string;
+  /** 'tp' = take-profit, 'sl' = stop-loss. */
+  tpsl: Tpsl;
+}
+
+export interface CancelArgs {
+  assetIndex: number;
+  /** Exchange order id (oid) of the resting order to cancel. */
+  oid: number;
+}
+
+// The SDK method arguments are the action content WITHOUT the `type` discriminator
+// (the client injects it). We mirror those shapes here as the builder outputs.
+export interface TriggerOrderParams {
+  orders: Array<{
+    a: number;
+    b: boolean;
+    p: string;
+    s: string;
+    r: boolean;
+    t: { trigger: { isMarket: boolean; triggerPx: string; tpsl: Tpsl } };
+  }>;
+  grouping: 'na';
+}
+
+export interface CancelParams {
+  cancels: Array<{ a: number; o: number }>;
+}
+
+/**
+ * The side that CLOSES a position of the given direction. A reduce-only order
+ * must be on the opposite side of the open position:
+ *   LONG  → sell (isBuy=false)
+ *   SHORT → buy  (isBuy=true)
+ */
+export function closingSide(positionSide: 'LONG' | 'SHORT'): boolean {
+  return positionSide === 'SHORT';
+}
+
+/**
+ * Pure builder for a reduce-only trigger (TP/SL) order action.
+ * Always r:true, isMarket:true, p:"0" (market-execute trigger), grouping:"na".
+ * No network, no signing — safe to unit-test.
+ */
+export function buildTriggerOrderParams(args: PlaceTriggerArgs): TriggerOrderParams {
+  const { assetIndex, isBuy, size, triggerPx, tpsl } = args;
+  if (!Number.isInteger(assetIndex) || assetIndex < 0) {
+    throw new Error(`invalid assetIndex: ${assetIndex}`);
+  }
+  return {
+    orders: [
+      {
+        a: assetIndex,
+        b: isBuy,
+        p: '0', // market trigger — price is "0"
+        s: size,
+        r: true, // reduce-only: the native safety guard
+        t: { trigger: { isMarket: true, triggerPx, tpsl } },
+      },
+    ],
+    grouping: 'na',
+  };
+}
+
+/** Pure builder for a cancel action. No network, no signing. */
+export function buildCancelParams(args: CancelArgs): CancelParams {
+  const { assetIndex, oid } = args;
+  if (!Number.isInteger(assetIndex) || assetIndex < 0) {
+    throw new Error(`invalid assetIndex: ${assetIndex}`);
+  }
+  if (!Number.isInteger(oid) || oid < 0) {
+    throw new Error(`invalid oid: ${oid}`);
+  }
+  return { cancels: [{ a: assetIndex, o: oid }] };
+}
+
+/** Result of a successful place: the resting order id (or a fill), plus raw. */
+export interface PlaceResult {
+  oid: number | null;
+  resting: boolean;
+  filled: boolean;
+  raw: unknown;
+}
+
+/**
+ * Extract the oid / status from an ExchangeClient.order() success response.
+ * Throws if the exchange returned a per-order error string.
+ */
+export function parseOrderResult(resp: unknown): PlaceResult {
+  const status = (resp as any)?.response?.data?.statuses?.[0];
+  if (status && typeof status.error === 'string') {
+    throw new Error(status.error);
+  }
+  if (status?.resting) {
+    return { oid: status.resting.oid ?? null, resting: true, filled: false, raw: resp };
+  }
+  if (status?.filled) {
+    return { oid: status.filled.oid ?? null, resting: false, filled: true, raw: resp };
+  }
+  return { oid: null, resting: false, filled: false, raw: resp };
+}
+
+/**
+ * Place a reduce-only trigger order via a signed L1 action. The `client` is an
+ * @nktkas/hyperliquid ExchangeClient bound to the user's window.ethereum wallet.
+ * Returns the resulting resting-order id. LIVE — only called behind the flag,
+ * after the match-guard, on explicit user confirm.
+ */
+export async function placeTrigger(
+  client: ExchangeClient,
+  args: PlaceTriggerArgs,
+): Promise<PlaceResult> {
+  const params = buildTriggerOrderParams(args);
+  const resp = await client.order(params);
+  return parseOrderResult(resp);
+}
+
+/** Cancel a resting reduce-only order via a signed L1 action. LIVE. */
+export async function cancel(client: ExchangeClient, args: CancelArgs): Promise<unknown> {
+  const params = buildCancelParams(args);
+  return client.cancel(params);
+}
+
+// ── Formatting helpers (HL wire format) ──────────────────────────────────────
+// HL perp prices allow at most 5 SIGNIFICANT figures (and ≤6 decimal places);
+// integer prices are exempt from the sig-fig cap. This is a BEST-EFFORT format
+// for the MVP — exact per-asset tick/lot rounding (needs `szDecimals` from meta)
+// is a follow-up the live place/cancel round-trip will validate. Returns a plain
+// decimal string (no exponent, no trailing zeros).
+export function formatPx(price: number): string {
+  if (!Number.isFinite(price) || price <= 0) throw new Error(`invalid price: ${price}`);
+  let s: string;
+  if (price >= 100000 || Number.isInteger(price)) {
+    s = Math.round(price).toString();
+  } else {
+    s = price.toPrecision(5);
+  }
+  // Strip any exponent / trailing zeros, clamp to 6 decimals.
+  let n = Number(s);
+  const fixed = n.toFixed(6);
+  return fixed.replace(/\.?0+$/, '');
+}
+
+/** Format a size (base-coin units) to a plain positive decimal string. */
+export function formatSize(size: number): string {
+  const a = Math.abs(size);
+  if (!Number.isFinite(a) || a <= 0) throw new Error(`invalid size: ${size}`);
+  return a.toFixed(8).replace(/\.?0+$/, '');
+}

--- a/src/data/hlWallet.ts
+++ b/src/data/hlWallet.ts
@@ -1,0 +1,101 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// #202 — In-browser wallet connector for HL order signing.
+//
+// Connects to the user's injected EIP-1193 provider (window.ethereum, e.g.
+// MetaMask), requests the active account, and builds a viem WalletClient the
+// @nktkas/hyperliquid ExchangeClient uses to sign L1 order actions IN THE BROWSER.
+//
+// NOTHING key-shaped is persisted anywhere — the private key never leaves the
+// user's wallet extension; we only ever hold the public address + a client that
+// asks the extension to sign. Absent-provider is handled gracefully (returns a
+// typed error, never throws an unhandled).
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { WalletClient } from 'viem';
+import type { ExchangeClient } from '@nktkas/hyperliquid';
+
+// The heavy signing deps (viem + the HL SDK, ~200KB) are DYNAMICALLY imported
+// only inside connectWallet(), which runs solely when the flag is on and the user
+// acts. This keeps them OUT of the default (flag-off) prod bundle — the dark
+// feature costs nothing until it's turned on and used.
+
+/** Minimal EIP-1193 provider shape (what MetaMask injects at window.ethereum). */
+export interface Eip1193Provider {
+  request(args: { method: string; params?: unknown[] | object }): Promise<unknown>;
+  on?(event: string, handler: (...args: unknown[]) => void): void;
+  removeListener?(event: string, handler: (...args: unknown[]) => void): void;
+}
+
+declare global {
+  interface Window {
+    ethereum?: Eip1193Provider;
+  }
+}
+
+export interface Connection {
+  /** The connected EOA address, lower-cased. */
+  address: string;
+  /** viem WalletClient over the injected provider (signs via the extension). */
+  walletClient: WalletClient;
+  /** HL ExchangeClient bound to the wallet — ready to place/cancel orders. */
+  exchange: ExchangeClient;
+}
+
+/** Returns the injected provider, or null if no wallet extension is present. */
+export function getProvider(): Eip1193Provider | null {
+  if (typeof window === 'undefined') return null;
+  return window.ethereum ?? null;
+}
+
+export function hasWallet(): boolean {
+  return getProvider() !== null;
+}
+
+/**
+ * Prompt the user's wallet to connect and return the active account + a signing
+ * client. Throws a descriptive Error when no provider is present or the user
+ * rejects the connection — callers surface it in the confirm UI.
+ */
+export async function connectWallet(): Promise<Connection> {
+  const provider = getProvider();
+  if (!provider) {
+    throw new Error('No browser wallet detected. Install MetaMask (or another EIP-1193 wallet) to place orders.');
+  }
+
+  // eth_requestAccounts prompts the extension's connect dialog.
+  const accounts = (await provider.request({ method: 'eth_requestAccounts' })) as string[];
+  const address = (accounts?.[0] ?? '').toLowerCase();
+  if (!address) {
+    throw new Error('Wallet returned no account. Unlock your wallet and try again.');
+  }
+
+  const [{ createWalletClient, custom }, { ExchangeClient, HttpTransport }] = await Promise.all([
+    import('viem'),
+    import('@nktkas/hyperliquid'),
+  ]);
+
+  const walletClient = createWalletClient({
+    account: address as `0x${string}`,
+    transport: custom(provider),
+  });
+
+  const exchange = new ExchangeClient({
+    wallet: walletClient,
+    transport: new HttpTransport(),
+  });
+
+  return { address, walletClient, exchange };
+}
+
+/** Read the currently-authorized address WITHOUT prompting (eth_accounts). */
+export async function currentAddress(): Promise<string | null> {
+  const provider = getProvider();
+  if (!provider) return null;
+  try {
+    const accounts = (await provider.request({ method: 'eth_accounts' })) as string[];
+    const a = accounts?.[0];
+    return a ? a.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,10 @@ interface ImportMetaEnv {
   readonly VITE_HASURA_HTTP?: string;
   readonly VITE_HASURA_WS?: string;
   readonly VITE_AUTH_URL?: string;
+  // #202 dark-launch flag for the reduce-only HL TP/SL "set-and-rest" feature.
+  // When absent or !== 'true' the entire in-browser order-placement surface is
+  // hidden and its code paths never run. Default OFF so prod stays read-only.
+  readonly VITE_ENABLE_HL_ORDERS?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## What

Dark-launched, PR-only MVP of **#202**: reduce-only TP/SL **"set-and-rest"** order placement for Hyperliquid PERPs, where the user's **own browser wallet** (`window.ethereum` / MetaMask) signs the Hyperliquid L1 order action **in-browser**. No stored keys, ever. `reduceOnly:true` is the native on-exchange guard.

Everything is gated behind the build-time flag **`VITE_ENABLE_HL_ORDERS`** (default **OFF**), so the feature is invisible and inert in prod until explicitly enabled.

## The 4 new modules (+ UI)

| File | Role |
|---|---|
| `src/data/hlMeta.ts` | Symbol→asset-index resolver. Fetches + caches `POST /info {"type":"meta"}` `universe[]`; `symbolToIndex(sym)`. |
| `src/data/hlOrders.ts` | **Pure** action-shape builders (`buildTriggerOrderParams`, `buildCancelParams`) + `placeTrigger`/`cancel` client over `@nktkas/hyperliquid` `ExchangeClient`. Always `r:true`, `isMarket:true`, `p:"0"`, `grouping:"na"`. Also the `hlOrdersEnabled()` flag helper + `formatPx`/`formatSize`. |
| `src/data/hlWallet.ts` | `window.ethereum` connector → viem `WalletClient` → HL `ExchangeClient`. **Lazy-imports** viem + the SDK so they stay out of the default bundle. Absent-provider handled gracefully. |
| `src/data/hlGuard.ts` | **Match-guard** (pure): resolves a Position → Account and asserts the connected EOA == the account's owned parent `walletAddress`. |
| `src/components/HlOrderActions.tsx` | Flag-gated **Set TP / Set SL / Cancel** UI, embedded in `ExitPlanner`'s expanded body. Confirm-before-sign. |

## The flag / "dark" guarantee

- **Flag OFF (prod default):** the entire feature — *including viem + the HL SDK* — is **dead-code-eliminated**. Verified: **50-byte** bundle delta vs `main`, zero feature strings, zero dynamic imports in the output.
- **Flag ON:** feature is included; viem (~363 kB) + SDK (~99 kB) are **lazy chunks** loaded only when `connectWallet()` runs (user clicks Confirm & sign).

## Match-guard safety model

Before any signature goes out, `checkMatch` asserts the **connected wallet address == the account's owned parent EOA** (`Account.walletAddress`). Mismatch / empty / not-connected are **refused before signing**. This is the *intent* backstop; `reduceOnly` is the *on-exchange* backstop (an order here can only shrink an existing position — never open or flip one).

**Subaccounts are disabled** in this MVP (with a "subaccount signing not yet supported" note) when `account_identifier != wallet_address` or the account is typed `sub` — see open decision below.

## Safety / process

- **No stored keys.** The private key never leaves the user's extension; we only hold the public address + a client that asks the extension to sign.
- **NO live order was placed.** Build + typecheck + unit tests only.
- Worked in a fresh clone (`/home/claude/wd-202`), never touched the prod-bind-mounted `/opt/.../zif-app`.

## Gate results

- `npm run build` (runs `tsc -b` per #198) — **GREEN**.
- `npm test` — **109 passed** (8 files; 3 new: builders, `symbolToIndex`, match-guard incl. match/mismatch/empty/subaccount). Added a `"test": "vitest run"` script.
- All `VITE_ENABLE_HL_ORDERS` entry points confirmed guarded (single UI entry `<HlOrderActions>`, first line gates on `hlOrdersEnabled()`).

## Remaining live-test (needs operator authorization)

The **place → rest → cancel round-trip against `api.hyperliquid.xyz` with a real wallet** was intentionally NOT run. It needs operator go-ahead (real funds / real signature on a live account).

## Open decisions for operator

1. **Subaccount signing.** MVP supports only MAIN accounts where the signing EOA == owner. HL subaccounts have a distinct `account_identifier` (on-chain sub-address) ≠ the parent `wallet_address`; placing for them needs a decision on the signing model (parent-EOA-signs-for-sub / agent wallet). Currently disabled with a note.
2. **Cancelling *pre-existing* venue orders.** `mat_resting_orders` does **not** expose the HL venue `oid` (the `RestingOrder` type has no `oid` field). So reliable Cancel is wired only to orders **placed in the current session** (where `placeTrigger` returns the `oid`). Cancelling arbitrary pre-existing resting orders needs a backend column exposing the venue `oid`.
3. **Price/size precision.** `formatPx` does best-effort 5-sig-fig rounding; exact per-asset tick/lot rounding needs `szDecimals` from `meta` — the live round-trip will surface any precision rejects.

Refs #202
