### PR TITLE
fix(#213): render stablecoin cash liability, exclude from tradeable positions

### DIFF
--- a/src/components/Positions.tsx
+++ b/src/components/Positions.tsx
@@ -5,6 +5,7 @@ import { t, exchMeta } from '../ui/theme';
 import { k, kc, col, px, usd, shortAddr } from '../lib/format';
 import { exchChipStyle, WALLET_CHIP, ACCOUNT_CHIP, ColorChip, walletLabelOf, accountLabelOf } from '../lib/tags';
 import { distToLiq, hasDisplayableLiq } from '../lib/pnl';
+import { isCashPosition, cashValue } from '../lib/cash';
 import { lifecycleKey } from '../data/DataSource';
 import { ExitPlanner } from './ExitPlanner';
 import { useIsMobile } from '../lib/useIsMobile';
@@ -186,7 +187,12 @@ function accountLabel(p: Position): string {
  * subscription (`s.positions`) is untouched.
  */
 export function PositionsSection() {
-  const positions = useStore((s) => s.positions);
+  const storePositions = useStore((s) => s.positions);
+  const cash = useStore((s) => s.cash);
+  // #213 defence-in-depth: the store already partitions cash out of `positions`,
+  // but re-filter here so this section can NEVER group/aggregate/dust a cash row
+  // even if a future ingest path forgets to split (a cash `units` is a signed $).
+  const positions = useMemo(() => storePositions.filter((p) => !isCashPosition(p)), [storePositions]);
   const posGroup = useStore((s) => s.posGroup);
   const setPosGroup = useStore((s) => s.setPosGroup);
   const posSort = useStore((s) => s.posSort);
@@ -313,10 +319,52 @@ export function PositionsSection() {
         {hiddenGroups.length > 0 && (
           <HiddenGroups groups={hiddenGroups} value={hiddenGroupsValue} />
         )}
+        {/* #213: stablecoin CASH / liabilities — a distinct, display-only strip.
+            NOT tradeable positions (no side/exit/risk); their value is already in
+            equity via mat_portfolio, so nothing here is summed into any total. */}
+        <CashLiabilities rows={cash} />
       </div>
     </section>
   );
 }
+
+/**
+ * Compact "Cash & Liabilities" strip (#213). One line per stablecoin cash row:
+ * exchange · asset · (wallet) · signed USD value. Since mark == 1 the value is the
+ * signed `units` (negative for an over-draw / borrow liability), which renders red
+ * with a "· Liability" tag; a positive cash balance renders neutral. Display-only —
+ * these rows are excluded from every position aggregate/exposure/PnL total.
+ */
+const CashLiabilities: React.FC<{ rows: Position[] }> = ({ rows }) => {
+  if (rows.length === 0) return null;
+  return (
+    <div>
+      <div style={{ fontSize: 10.5, letterSpacing: '.05em', color: t.mut2, textTransform: 'uppercase', marginBottom: 8 }}>
+        Cash &amp; Liabilities
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {rows.map((c) => {
+          const value = cashValue(c);            // mark == 1 → value == units
+          const isLiab = value < 0;
+          // Signed "−$71,404.30" / "$1,234.56" (leading minus glyph, not "$-…").
+          const amount = `${isLiab ? '−' : ''}$${Math.abs(value).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+          return (
+            <Card key={c.id} style={{ padding: '10px 14px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                <ColorChip {...exchChipStyle(c.exch)}>{c.exch}</ColorChip>
+                {walletLabel(c) && <ColorChip {...WALLET_CHIP}>{walletLabel(c)}</ColorChip>}
+                <span style={{ flex: 1 }} />
+                <Mono style={{ fontSize: 14, fontWeight: 600, color: isLiab ? t.red : t.text }}>
+                  {c.asset} {amount}{isLiab ? ' · Liability' : ''}
+                </Mono>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
 
 type Group = {
   key: string;
@@ -519,7 +567,10 @@ function PositionRow({ p, groupNegPL }: { p: Position; groupNegPL: number }) {
             </div>
           )}
 
-          <ExitPlanner p={p} />
+          {/* #213: a cash/liability row is never a tradeable position, so it must
+              never render an exit/risk chart. It can't reach here today (cash is
+              partitioned out of the row list), but guard explicitly on a money path. */}
+          {!isCashPosition(p) && <ExitPlanner p={p} />}
         </div>
       )}
     </Card>

--- a/src/data/apolloSource.ts
+++ b/src/data/apolloSource.ts
@@ -28,6 +28,7 @@ import type {
 } from '../types';
 import type { OmniRawEventInsert } from '../lib/omniCsvParser';
 import { shortAddr } from '../lib/format';
+import { isCashPosition } from '../lib/cash';
 import { getToken } from './authStore';
 import { pushError } from '../lib/errorBus';
 
@@ -130,7 +131,7 @@ const lifecycleMap = (rows: any[]): LifecycleMap => {
  *  - netLong/gross = signed / abs notional from positions (units × mark)
  *  - risks        = # positions inside 10% of liquidation
  */
-const aggregatePortfolio = (rows: any[], positions: Position[]): Portfolio => {
+export const aggregatePortfolio = (rows: any[], positions: Position[]): Portfolio => {
   let value = 0, unrealTotal = 0, eq24 = 0;
   for (const r of rows) {
     value += num(r.equity);
@@ -142,6 +143,10 @@ const aggregatePortfolio = (rows: any[], positions: Position[]): Portfolio => {
 
   let netLong = 0, gross = 0, risks = 0;
   for (const p of positions) {
+    // #213: a cash/liability row (type === 'cash') is NOT tradeable — its `units`
+    // is a signed dollar amount, so summing it into gross/netLong would corrupt
+    // exposure. Skip it (its value already lives in mat_portfolio equity).
+    if (isCashPosition(p)) continue;
     const notional = p.units * p.mark;
     const signed = p.side === 'LONG' ? notional : -notional;
     netLong += signed;

--- a/src/data/hlOrders.ts
+++ b/src/data/hlOrders.ts
@@ -21,6 +21,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import type { ExchangeClient } from '@nktkas/hyperliquid';
+import type { Side } from '../types';
 
 /** True iff the dark-launch flag is explicitly enabled. Default OFF. */
 export function hlOrdersEnabled(): boolean {
@@ -74,8 +75,12 @@ export interface CancelParams {
  * must be on the opposite side of the open position:
  *   LONG  → sell (isBuy=false)
  *   SHORT → buy  (isBuy=true)
+ *
+ * Accepts the full `Side` union for call-site convenience; only perps ever reach
+ * HL order placement, so the #213 'LIABILITY' cash side never arrives here and is
+ * treated like a LONG-close (isBuy=false) purely to satisfy the type.
  */
-export function closingSide(positionSide: 'LONG' | 'SHORT'): boolean {
+export function closingSide(positionSide: Side): boolean {
   return positionSide === 'SHORT';
 }
 

--- a/src/data/mockEngine.ts
+++ b/src/data/mockEngine.ts
@@ -9,6 +9,7 @@ import type {
 } from '../types';
 import type { OmniRawEventInsert } from '../lib/omniCsvParser';
 import { pnlAt } from '../lib/pnl';
+import { isCashPosition } from '../lib/cash';
 import { realizedNet } from '../lib/income';
 import {
   seedPositions, seedLevels, seedOrders, seedWallets, seedClosedTrades, seedActivity,
@@ -75,6 +76,8 @@ export class MockEngine {
 
   private tick() {
     for (const p of this.positions) {
+      // #213 cash/liability rows are pinned at mark=1 / unreal=0 — never drift them.
+      if (isCashPosition(p)) continue;
       const volBps = p.type === 'spot' ? 0.0011 : 0.0016;
       const drift = (Math.random() - 0.5) * 2 * p.mark * volBps;
       p.mark = Math.max(p.mark + drift, p.mark * 0.5);
@@ -88,18 +91,25 @@ export class MockEngine {
   }
 
   private computePortfolio(): Portfolio {
-    const gross = this.positions.reduce((s, p) => s + Math.abs(p.units * p.mark), 0);
-    const netLong = this.positions.reduce((s, p) => s + (p.side === 'LONG' ? 1 : -1) * p.units * p.mark, 0);
-    const unrealTotal = this.positions.reduce((s, p) => s + p.unreal, 0);
+    // #213: exclude cash/liability rows from every exposure/PnL aggregate — their
+    // `units` is a signed dollar amount, not a tradeable size. Mirrors the live
+    // aggregatePortfolio() guard so the mock stays money-neutral too.
+    const tradeable = this.positions.filter((p) => !isCashPosition(p));
+    const gross = tradeable.reduce((s, p) => s + Math.abs(p.units * p.mark), 0);
+    const netLong = tradeable.reduce((s, p) => s + (p.side === 'LONG' ? 1 : -1) * p.units * p.mark, 0);
+    const unrealTotal = tradeable.reduce((s, p) => s + p.unreal, 0);
     const value = 733102 + (unrealTotal - seedPositions.reduce((s, p) => s + p.unreal, 0));
-    const risks = this.positions.filter((p) => p.liq > 0 && Math.abs((p.liq - p.mark) / p.mark) < 0.12).length;
+    const risks = tradeable.filter((p) => p.liq > 0 && Math.abs((p.liq - p.mark) / p.mark) < 0.12).length;
     return { value, change24h: 71300, changePct: 10.78, netLong, gross, risks, unrealTotal };
   }
 
   private emitActivity() {
     const pool = ['FUNDING', 'FILL', 'CLOSE'];
     const act = pool[Math.floor(Math.random() * pool.length)];
-    const p = this.positions[Math.floor(Math.random() * this.positions.length)];
+    // #213: never synthesise trade activity from a cash/liability row.
+    const tradeable = this.positions.filter((p) => !isCashPosition(p));
+    if (tradeable.length === 0) return;
+    const p = tradeable[Math.floor(Math.random() * tradeable.length)];
     const pnl = act === 'CLOSE' ? Math.round((Math.random() - 0.3) * 2000) : act === 'FUNDING' ? Math.round(Math.random() * 120) : 0;
     const ev: ActivityEvent = {
       id: 'act' + Date.now(), ts: Date.now(), act,

--- a/src/data/mockSeed.ts
+++ b/src/data/mockSeed.ts
@@ -12,6 +12,11 @@ export const seedPositions: Position[] = [
   { id: 'SOL', asset: 'SOL', exch: 'Lighter', wallet: 'Dad Trading', walletLabel: 'Dad Trading', side: 'LONG', units: 80, entry: 142, mark: 151.2, liq: 96, lev: 3, type: 'PERP', unreal: 736, realized: 40 },
   { id: 'ETH', asset: 'ETH', exch: 'Lighter', wallet: 'Dad Trading', walletLabel: 'Dad Trading', side: 'LONG', units: 4, entry: 3050, mark: 3192, liq: 2400, lev: 3, type: 'PERP', unreal: 568, realized: 30 },
   { id: 'MEGA', asset: 'MEGA', exch: 'Hyperliquid', wallet: 'Main', walletLabel: 'Hype Trading', side: 'SHORT', units: 40000, entry: 0.0612, mark: 0.0461, liq: 0.092, lev: 4, type: 'PERP', unreal: 604, realized: 12 },
+  // #213 stablecoin CASH liability (over-draw): type 'cash', side 'LIABILITY',
+  // signed negative units, entry=mark=1 so value==units, unreal=realized=0. It is
+  // partitioned OUT of the tradeable positions (lib/cash.ts) and rendered in the
+  // "Cash & Liabilities" strip — never counted in any exposure/PnL total.
+  { id: 'USDC-CASH', asset: 'USDC', exch: 'Hyperliquid', wallet: 'Main', walletLabel: 'Hype Trading', side: 'LIABILITY', units: -71404.30, entry: 1, mark: 1, liq: 0, lev: 0, type: 'cash', unreal: 0, realized: 0 },
 ];
 
 export const seedLevels: OrderLevel[] = [

--- a/src/lib/cash.test.ts
+++ b/src/lib/cash.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { isCashPosition, partitionCash, cashValue } from './cash';
+import { aggregatePortfolio } from '../data/apolloSource';
+import { useStore } from '../store/store';
+import type { Position } from '../types';
+
+// Minimal Position factory — override only what a case cares about.
+const pos = (over: Partial<Position>): Position => ({
+  id: 'p', asset: 'BTC', exch: 'Hyperliquid', wallet: '', walletLabel: '',
+  side: 'LONG', units: 1, entry: 100, mark: 110, liq: 0, lev: 1,
+  type: 'perp', unreal: 10, realized: 0, ...over,
+});
+
+// A representative #213 stablecoin CASH liability: negative units, entry=mark=1,
+// side LIABILITY, unreal=realized=0. Value == units == -71404.30.
+const cashRow = (over: Partial<Position> = {}): Position => pos({
+  id: 'USDC-CASH', asset: 'USDC', side: 'LIABILITY', units: -71404.30,
+  entry: 1, mark: 1, liq: 0, lev: 0, type: 'cash', unreal: 0, realized: 0, ...over,
+});
+
+describe('isCashPosition (#213)', () => {
+  it('recognises type "cash" case-insensitively', () => {
+    expect(isCashPosition({ type: 'cash' })).toBe(true);
+    expect(isCashPosition({ type: 'CASH' })).toBe(true);
+    expect(isCashPosition({ type: 'Cash' })).toBe(true);
+  });
+  it('rejects tradeable + empty types', () => {
+    expect(isCashPosition({ type: 'perp' })).toBe(false);
+    expect(isCashPosition({ type: 'PERP' })).toBe(false);
+    expect(isCashPosition({ type: 'spot' })).toBe(false);
+    expect(isCashPosition({ type: '' })).toBe(false);
+    expect(isCashPosition({ type: undefined as any })).toBe(false);
+  });
+});
+
+describe('partitionCash (#213)', () => {
+  it('splits tradeable vs cash and preserves order within each bucket', () => {
+    const rows = [pos({ id: 'a', type: 'perp' }), cashRow({ id: 'c1' }), pos({ id: 'b', type: 'spot' }), cashRow({ id: 'c2' })];
+    const { positions, cash } = partitionCash(rows);
+    expect(positions.map((p) => p.id)).toEqual(['a', 'b']);
+    expect(cash.map((p) => p.id)).toEqual(['c1', 'c2']);
+  });
+});
+
+describe('cashValue (#213)', () => {
+  it('is the signed units (mark == 1)', () => {
+    expect(cashValue(cashRow())).toBeCloseTo(-71404.30, 5);
+    expect(cashValue(cashRow({ units: 5000, mark: 1 }))).toBe(5000); // positive cash allowed
+  });
+  it('drives the display sign — a liability is negative (red) with a Liability tag', () => {
+    const v = cashValue(cashRow());
+    const isLiab = v < 0;
+    const amount = `${isLiab ? '−' : ''}$${Math.abs(v).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    expect(isLiab).toBe(true);
+    expect(`USDC ${amount}${isLiab ? ' · Liability' : ''}`).toBe('USDC −$71,404.30 · Liability');
+  });
+});
+
+describe('aggregatePortfolio money-neutrality (#213)', () => {
+  // mat_portfolio rows drive equity/unrealized; positions drive netLong/gross/risks.
+  const pfRows = [{ equity: 733102, unrealized: -6774, equity_24h_ago: 661802 }];
+  const tradeable = [
+    pos({ id: 'BTC', side: 'LONG', units: 1, mark: 63152, liq: 59370, unreal: -3800 }),
+    pos({ id: 'JTO', side: 'SHORT', units: 12000, mark: 0.661, liq: 0.83, unreal: 348 }),
+  ];
+
+  it('adding a cash row changes NO exposure/equity total', () => {
+    const withoutCash = aggregatePortfolio(pfRows, tradeable);
+    const withCash = aggregatePortfolio(pfRows, [...tradeable, cashRow()]);
+    expect(withCash.value).toBe(withoutCash.value);             // equity unchanged
+    expect(withCash.unrealTotal).toBe(withoutCash.unrealTotal); // unrealized unchanged
+    expect(withCash.netLong).toBe(withoutCash.netLong);         // net exposure unchanged
+    expect(withCash.gross).toBe(withoutCash.gross);             // gross exposure unchanged
+    expect(withCash.risks).toBe(withoutCash.risks);
+  });
+
+  it('does NOT sum the cash units (a signed $) into gross/netLong', () => {
+    const agg = aggregatePortfolio(pfRows, [cashRow()]); // cash-only
+    expect(agg.gross).toBe(0);   // would be 71404.30 if cash leaked into exposure
+    expect(agg.netLong).toBe(0); // would be -71404.30 (phantom short) if it leaked
+  });
+});
+
+describe('store _ingestPositions split (#213)', () => {
+  it('keeps cash out of positions and exposes it separately', () => {
+    const rows = [pos({ id: 'BTC', type: 'perp' }), cashRow(), pos({ id: 'HYPE', type: 'spot' })];
+    useStore.getState()._ingestPositions(rows);
+    const s = useStore.getState();
+    expect(s.positions.map((p) => p.id)).toEqual(['BTC', 'HYPE']);
+    expect(s.positions.some(isCashPosition)).toBe(false);
+    expect(s.cash.map((p) => p.id)).toEqual(['USDC-CASH']);
+    // long/short counts (as Overview/Positions derive them) exclude cash:
+    const longs = s.positions.filter((p) => p.side === 'LONG').length;
+    expect(s.positions.length).toBe(2);
+    expect(longs).toBe(2);
+  });
+});

--- a/src/lib/cash.ts
+++ b/src/lib/cash.ts
@@ -1,0 +1,46 @@
+// ── Stablecoin CASH / liability rows (#213) ──────────────────────────────────
+// The backend materializer emits a distinct kind of mat_positions row to model a
+// negative stablecoin CASH balance (an over-draw / borrow liability) instead of
+// letting it masquerade as a phantom short/long position. These rows carry:
+//   type = 'cash'      (existing rows are 'perp' | 'spot')
+//   side = 'LIABILITY'
+//   units = the SIGNED cash balance (NEGATIVE for a liability, e.g. -71404.30)
+//   entry = 1, mark = 1, unreal = 0, realized = 0
+//   asset = the stablecoin symbol (USDC / USDE / USDT / DAI / …)
+// Because mark = 1 the row's USD value == units (a signed dollar amount), and
+// unreal = 0 so it CANNOT affect any P/L total by construction.
+//
+// A cash row is NOT a tradeable position: it must be excluded from long/short
+// counts, gross/net exposure sums, dust bucketing, and every risk/exit chart —
+// and rendered instead in a distinct "Cash & Liabilities" display. This module is
+// the SINGLE source of truth for that classification so every surface agrees.
+
+import type { Position } from '../types';
+
+/** True for a stablecoin CASH / liability row (#213). Case-insensitive on `type`. */
+export function isCashPosition(p: Pick<Position, 'type'>): boolean {
+  return (p.type ?? '').toLowerCase() === 'cash';
+}
+
+/**
+ * Split a mixed mat_positions set into tradeable `positions` vs `cash` rows,
+ * preserving order within each bucket. Used at the ingest boundary so every
+ * downstream consumer of the tradeable list is cash-free automatically.
+ */
+export function partitionCash<T extends Pick<Position, 'type'>>(
+  rows: T[],
+): { positions: T[]; cash: T[] } {
+  const positions: T[] = [];
+  const cash: T[] = [];
+  for (const r of rows) (isCashPosition(r) ? cash : positions).push(r);
+  return { positions, cash };
+}
+
+/**
+ * Signed USD value of a cash row. mark == 1 by construction, so this is just the
+ * signed `units` (negative for a liability). Isolated here so the display never
+ * re-derives it inconsistently.
+ */
+export function cashValue(p: Pick<Position, 'units' | 'mark'>): number {
+  return p.units * p.mark;
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { partitionCash } from '../lib/cash';
 import type {
   Position, Portfolio, Wallet, OrderLevel, RestingOrder, ActivityEvent, Tab, Timeframe, PerfDim, PerfStatus, LifecycleMap,
   DriftSnapshot, PnlGranularity, PnlGroupBy,
@@ -28,7 +29,15 @@ function mergeWallets(server: Wallet[], pending: Wallet[]): Wallet[] {
 }
 
 interface ServerState {
+  // TRADEABLE positions only. #213 cash/liability rows (type === 'cash') are
+  // partitioned OUT here (into `cash` below) at ingest, so every consumer of
+  // `positions` — long/short counts, gross/net exposure, dust, risk/exit charts —
+  // is cash-free by construction and no money total can pick up a cash `units`.
   positions: Position[];
+  // #213 stablecoin CASH / liability rows (negative cash over-draws). Display-only,
+  // rendered in the "Cash & Liabilities" strip; NEVER summed into any exposure/
+  // equity/PnL total (equity already reflects the negative cash via mat_portfolio).
+  cash: Position[];
   portfolio: Portfolio | null;
   // Open-lifecycle enrichment (Stream B, zif #212): the exchange-style per-open
   // fields keyed by lifecycleKey(). The Positions detail looks up its Position's
@@ -248,6 +257,7 @@ function readLastChecked(): number {
 export const useStore = create<StoreState>((set) => ({
   // server
   positions: [],
+  cash: [],
   portfolio: null,
   lifecycle: {},
   wallets: [],
@@ -335,7 +345,15 @@ export const useStore = create<StoreState>((set) => ({
   },
   // server ingest. Stamp lastUpdate on every hot-stream push so the header can
   // detect a stalled feed.
-  _ingestPositions: (positions) => set({ positions, lastUpdate: Date.now() }),
+  // #213: split the raw mat_positions push into tradeable positions vs cash/
+  // liability rows. `positions` (tradeable only) drives ALL exposure/PnL/risk
+  // surfaces; `cash` is display-only. Splitting HERE — the single ingest
+  // chokepoint shared by the live and mock paths — guarantees no downstream
+  // consumer accidentally treats a cash `units` (a signed dollar amount) as size.
+  _ingestPositions: (rows) => {
+    const { positions, cash } = partitionCash(rows);
+    set({ positions, cash, lastUpdate: Date.now() });
+  },
   _ingestPortfolio: (portfolio) => set({ portfolio, lastUpdate: Date.now() }),
   // Lifecycle is a slow-moving enrichment map (not a hot per-tick stream), so it
   // writes straight through — no rAF batching, no lastUpdate stamp.

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,11 @@
 // These mirror the shape of the GraphQL documents in src/graphql/operations.ts.
 // In real mode they come from Hasura; in mock mode the engine emits the same shapes.
 
-export type Side = 'LONG' | 'SHORT';
+// 'LIABILITY' is carried ONLY by #213 stablecoin CASH rows (type === 'cash'):
+// a negative-cash over-draw / borrow. It is NOT a tradeable direction — cash rows
+// are partitioned out of the tradeable position list (see lib/cash.ts) before any
+// LONG/SHORT logic runs, so the exposure/PnL math never sees it.
+export type Side = 'LONG' | 'SHORT' | 'LIABILITY';
 export type Exchange = 'Hyperliquid' | 'Lighter' | 'Drift' | 'Variational' | 'Binance';
 export type LadderKind = 'tp' | 'sl';
 export type Accuracy = 'synced' | 'gap' | 'mismatch' | 'pending' | 'nokey';
@@ -30,7 +34,7 @@ export interface Position {
   mark: number;       // live — updated by subscription
   liq: number;
   lev: number;
-  type: string;       // PERP / spot
+  type: string;       // PERP / spot / cash (#213 stablecoin liability, see lib/cash.ts)
   unreal: number;     // live
   realized: number;
   staked?: boolean;   // true for staked-pool bags (mat_positions.asset ended in -POOL);


### PR DESCRIPTION
## Issue
Fixes zif-terminal/infrastructure#213 (frontend half). Pairs with the `exchange-gateway` PR that emits `type='cash'` rows.

## Gap analysis
The zif-app had **no concept of cash/liability**. A stablecoin row from `mat_positions` flowed straight through `mapPosition` as a normal position: it would render a red "SHORT"/"SPOT" card, be counted in the long/short header, summed into gross/net exposure, and even draw an ExitPlanner TP/SL chart — i.e. the exact "phantom short" #213 describes. (Today it's masked only by the denomination filter + dust threshold; this makes the handling correct and robust.)

## Fix
The backend now emits a distinct `type='cash'` row (`side='LIABILITY'`, `units` = signed balance, `mark=1`, `unreal=0`). The FE treats it as **not a tradeable position**:
- **`src/lib/cash.ts`** (new) — single source of truth: `isCashPosition`, `partitionCash`, `cashValue`.
- **`src/store/store.ts`** — `_ingestPositions` partitions every push at the single ingest chokepoint into tradeable `positions` (cash-free) + a display-only `cash` slice, so Overview/RiskPlan/Positions are cash-free automatically.
- **`src/data/apolloSource.ts`** — `aggregatePortfolio` skips cash in the gross/netLong loop (equity/unrealized still come solely from `mat_portfolio`).
- **`src/data/mockEngine.ts` / `mockSeed.ts`** — mock excludes cash from exposure/pnl and seeds a representative liability so the display renders in dev.
- **`src/components/Positions.tsx`** — reads `s.cash`, guards the per-row `ExitPlanner` with `!isCashPosition`, and adds a compact **Cash & Liabilities** strip (`USDC −$71,404.30 · Liability` in red).
- **`src/types.ts` / `hlOrders.ts`** — `Side` widened to include `'LIABILITY'`.

Defense-in-depth: exclusion is enforced at the store (primary) and re-asserted in `PositionsSection` + the `ExitPlanner` render guard.

## Tests + build
- `npm test` (vitest): **9 files, 117 tests pass** (independently re-run).
- `npm run build` (`tsc -b && vite build`): **pass** (only the pre-existing >500 kB chunk advisory).
- New `src/lib/cash.test.ts`: predicate/partition/value helpers; **money-neutrality** of `aggregatePortfolio` (adding a cash row changes no value/unrealTotal/netLong/gross/risks); a cash-only book yields gross=0/netLong=0 (its negative `units` never leaks into exposure); the display sign string; the real store `_ingestPositions` split.

## Money impact — NONE
Equity/unrealized/realized totals derive solely from `mat_portfolio` (untouched). Cash rows carry `unreal=0`/`realized=0` and are partitioned out of the tradeable list at ingest, so their negative `units` (a signed dollar amount) is never summed into any exposure/equity/PnL total — proven by the neutrality test. The Cash & Liabilities strip is display-only.

## Apply / deploy
Static Vite `zif-app`. Build with LIVE env (HARD gate — `VITE_USE_MOCK=false` + `VITE_HASURA_HTTP/WS/AUTH` set; grep the bundle for `wss://zif-prod…/v1/graphql` before swap), stage-build + atomic-swap (clobber-free), then run the real-login QA harness (`qa/real-login-probe.mjs`) and confirm a cash liability renders in the strip and NOT as a position card. Deploy together with / after the gateway PR.

## Live-verify
On an account with a known over-draw, confirm the "Cash & Liabilities" strip shows the signed liability, the position count/long-short header excludes it, no ExitPlanner chart renders for it, and the Overview equity/unrealized match pre-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww1rWnKu1dcfkK57i1UmGu
