### PR TITLE
fix(#202): isOrderablePosition matches lowercase perp (real data)

### DIFF
--- a/src/data/hlGuard.test.ts
+++ b/src/data/hlGuard.test.ts
@@ -19,7 +19,7 @@ const wallet = (accounts: Account[]): Wallet => ({
 const pos = (over: Partial<Position>): Position => ({
   id: 'p1', exchangeAccountId: 'acc1', asset: 'HYPE', exch: 'Hyperliquid', wallet: 'main',
   walletLabel: '', side: 'LONG', units: 10, entry: 40, mark: 42, liq: 20, lev: 3,
-  type: 'PERP', unreal: 20, realized: 0, ...over,
+  type: 'perp', unreal: 20, realized: 0, ...over,
 });
 
 describe('findAccount', () => {

--- a/src/data/hlGuard.ts
+++ b/src/data/hlGuard.ts
@@ -111,5 +111,5 @@ export function guardPosition(
  * the caller so this stays a pure predicate.)
  */
 export function isOrderablePosition(position: Position): boolean {
-  return position.exch === 'Hyperliquid' && position.type === 'PERP';
+  return position.exch === 'Hyperliquid' && position.type?.toLowerCase() === 'perp';
 }


### PR DESCRIPTION
The DB stores type=perp lowercase; the guard checked PERP uppercase → HL order buttons never rendered. Matches Positions.tsx toLowerCase pattern. Deployed live as index-8ioywtA-. Refs #202.